### PR TITLE
Make it clear what `kritis` is

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-This directory contains examples of [the Pipeline strawman CRDs](../README.md) in action.
+This directory contains examples of [the Pipeline CRDs](../README.md) in action.
 
 To deploy them to your cluster (after
 [installing the CRDs and running the controller](../DEVELOPMENT.md#installing-andrunning)):
@@ -10,6 +10,29 @@ kubectl apply -f examples/pipelines
 kubectl apply -f examples/
 kubectl apply -f examples/invocations
 ```
+
+## Example Pipelines
+
+We have 2 example [Pipelines](../README.md#pipeline) in [./pipelines](./pipelines)
+
+1. [The Kritis Pipline](./pipelines/kritis.yaml): This example builds a Pipeline for the
+   [kritis project](https://github.com/grafeas/kritis), and demonstrates how to configure
+    a pipeline which:
+
+    1. Runs unit tests
+    2. Build an image
+    3. Deploys it to a test environment
+    4. Runs integration tests
+
+   ![Pipeline Configuration](./pipelines/kritis-pipeline.png)
+
+2. [Guestbook](./pipelines/guestbook.yaml): This Pipeline is based on example application in
+   [the Kubernetes example Repo](https://github.com/kubernetes/examples/tree/master/guestbook)
+   This pipeline demonstartes how to integrate frontend
+   [guestbook app code](https://github.com/kubernetes/examples/tree/master/guestbook-go) with
+   backend [redis-docker image](https://github.com/GoogleCloudPlatform/redis-docker/tree/master/4) provided by GCP.
+
+   ![Pipeline Configuration](./pipelines/guestbook-pipeline.png)
 
 ## Example Tasks
 
@@ -34,16 +57,3 @@ The [runs](./runs/) dir contains an example [TaskRun](../README.md#taskrun) and 
 [run-kritis-test.yaml](./invocations/run-kritis-test.yaml) shows an example of how to manually run kritis unit test off your development branch.
 
 [kritis-pipeline-run.yaml](./invocations/kritis-pipeline-run.yaml) shows an example of what it would look like to invoke the [kritis example pipeline](#example-pipelines) manually and have it fail on the second task (building and pushing the image).
-
-## Example Pipelines
-
-Finally, we have 2 example [Pipelines](../README.md#pipeline) in [./pipelines](./pipelines)
-
-1. [Kritis](./pipelines/kritis.yaml): This exmaple demonstrates how to configure a pipeline which runs unit test, build an image, deploys it to test and then run integration tests. (This is the pipeline for [kritis](https://github.com/grafeas/kritis).)
-
-![Pipeline Configuration](./pipelines/kritis-pipeline.png)
-
-2. [Guestbook](./pipelines/guestbook.yaml): This is pipeline which is based on example application in [Kubernetes example Repo](https://github.com/kubernetes/examples/tree/master/guestbook)
-This pipeline demonstartes how to integrate frontend [guestbook app code](https://github.com/kubernetes/examples/tree/master/guestbook-go) with backed [redis-docker image](https://github.com/GoogleCloudPlatform/redis-docker/tree/master/4) provided by GCP.
-
-![Pipeline Configuration](./pipelines/guestbook-pipeline.png)

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,4 +56,10 @@ The [runs](./runs/) dir contains an example [TaskRun](../README.md#taskrun) and 
 
 [run-kritis-test.yaml](./invocations/run-kritis-test.yaml) shows an example of how to manually run kritis unit test off your development branch.
 
-[kritis-pipeline-run.yaml](./invocations/kritis-pipeline-run.yaml) shows an example of what it would look like to invoke the [kritis example pipeline](#example-pipelines) manually and have it fail on the second task (building and pushing the image).
+[kritis-pipeline-run.yaml](./invocations/kritis-pipeline-run.yaml) shows an example of
+what it would look like to invoke the [kritis example pipeline](#example-pipelines)
+manually. In the `conditions` field for type `Successful` you can see that the status
+is `False`, which indicates that the Pipeline was not run successfully. The field
+`message` contains a human readable error indicating that one of the `TaskRuns` failed.
+This `condition` (and everything else in the `status` section) would be populated by the
+controller as it realized the PipelineRun (i.e. ran the Pipeline).

--- a/examples/invocations/kritis-pipeline-run.yaml
+++ b/examples/invocations/kritis-pipeline-run.yaml
@@ -40,4 +40,4 @@ status:
       status: "False"
       lastTransitionTime: "2018-10-04T13:25:39Z"
       reason: taskFailure
-      message: "TaskRun `push-kritis-12321312984` had non-zero exit code"
+      message: "TaskRun `build-push-kritis-12321312984` had non-zero exit code"


### PR DESCRIPTION
One of the examples demonstrates building an arbitrary pipeline for
a project called `kritis`, mostly b/c folks who are working on this
project have also worked on `kritis` and are familiar with it, but it's
not actually relevant to `bulid-pipeline` directly. Tried to make this
more clear in the docs.

Also in #2 we had a question about what `strawman` means (not the first
time this has come up!) A defintion is avialable at https://en.wikipedia.org/wiki/Straw_man_proposal
but also mentions it is "american business jargon" so if we want to go
on using that term we should define it. Instead I removed it from the
one place it exists in our docs. Since no one has completely beaten up
the proposal yet it seems to be graduating beyond the "strawman" phase -
but correct me if I'm wrong :D