### PR TITLE
Dep script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: test manager
 
 # Run tests
 test: generate fmt vet manifests
-	go test ./pkg/... ./cmd/... -coverprofile cover.out
+	@ ./test.sh
 
 # Build manager binary
 manager: generate fmt vet

--- a/hack/boilerplate.sh
+++ b/hack/boilerplate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2018 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+BOILERPLATEDIR=$DIR/boilerplate
+
+files=$(python ${BOILERPLATEDIR}/boilerplate.py --rootdir . --boilerplate-dir ${BOILERPLATEDIR})
+
+if [[ ! -z ${files} ]]; then
+	echo "Boilerplate missing in:"
+    echo "${files}"
+	exit 1
+fi

--- a/hack/dep.sh
+++ b/hack/dep.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+DEP_VERSION=v0.5.0
+DEP_DIR="$GOPATH/src/github.com/golang/dep"
+
+install_dep() {
+    echo "Installing dep ${DEP_VERSION}"
+    if [ ! -d "$DEP_DIR" ]; then
+        go get -u -d github.com/golang/dep/cmd/dep
+    fi
+    cd $DEP_DIR
+    git checkout -q ${DEP_VERSION}
+    go build -o $GOPATH/bin/dep github.com/golang/dep/cmd/dep
+}
+
+if [ -z "$VALIDATE_UPSTREAM" ]; then
+	VALIDATE_REPO='https://github.com/knative/build-pipeline.git'
+	VALIDATE_BRANCH='master'
+
+	VALIDATE_HEAD="$(git rev-parse --verify HEAD)"
+
+	git fetch -q "$VALIDATE_REPO" "refs/heads/$VALIDATE_BRANCH"
+	VALIDATE_UPSTREAM="$(git rev-parse --verify FETCH_HEAD)"
+
+	VALIDATE_COMMIT_DIFF="$VALIDATE_UPSTREAM...$VALIDATE_HEAD"
+
+	validate_diff() {
+		if [ "$VALIDATE_UPSTREAM" != "$VALIDATE_HEAD" ]; then
+			git diff "$VALIDATE_COMMIT_DIFF" "$@"
+		fi
+	}
+fi
+# See if there have been upstream changes
+IFS=$'\n'
+files=( $(validate_diff --name-only -- 'Gopkg.toml' 'Gopkg.lock' 'vendor/' || true) )
+unset IFS
+
+if [ ${#files[@]} -gt 0 ]; then
+	if ! [ -x "$(command -v dep)" ]; then
+		install_dep
+	fi
+	dep ensure
+	diffs="$(git status --porcelain -- vendor Gopkg.toml Gopkg.lock 2>/dev/null)"
+	if [ "$diffs" ]; then
+		{
+			echo 'Vendor not reproducible, please commit these changes to fix.'
+			echo
+			echo "$diffs"
+		} >&2
+		false
+	fi
+else
+    echo 'No vendor changes from upstream. Skipping dep ensure, dep prune'
+fi

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2018 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+files=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -l -s)
+if [[ $files ]]; then
+    echo "Gofmt errors in files:"
+    echo "$files"
+    diff=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -d -s)
+    echo "$diff"
+    exit 1
+fi

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2018 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if ! [ -x "$(command -v golangci-lint)" ]; then
+	echo "Installing GolangCI-Lint"
+	${DIR}/install_golint.sh -b $GOPATH/bin v1.9.3
+fi
+
+golangci-lint run \
+	--no-config \
+	-E goconst \
+	-E goimports \
+	-E golint \
+	-E interfacer \
+	# -E maligned \ # TODO(aaron-prindle) reorder structs by size to get passing
+	-E misspell \
+	-E unconvert \
+	-E unparam \
+	-D errcheck \
+	pkg/... cmd/... test/...

--- a/pkg/apis/pipeline/v1beta1/sanity_test.go
+++ b/pkg/apis/pipeline/v1beta1/sanity_test.go
@@ -46,7 +46,7 @@ func assertResourceIsEqual(t *testing.T, name string, expected, fetched runtime.
 
 	c := context.Background()
 	if err := client.Get(c, key, fetched); err != nil {
-		t.Errorf("Couldn't retreive created resource %s from namespace %s: %s", name, namespace, err)
+		t.Errorf("Couldn't retrieve created resource %s from namespace %s: %s", name, namespace, err)
 	}
 
 	if !reflect.DeepEqual(fetched, expected) {
@@ -69,7 +69,7 @@ func createResource(t *testing.T, fileName, name string, created, fetched runtim
 		t.Fatalf("Controller failed to create resource from %s: %s", fileName, err)
 	}
 
-	// Retreive it
+	// Retrieve it
 	assertResourceIsEqual(t, name, created, fetched)
 }
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+echo "Running go tests..."
+go test -cover -v -timeout 60s `go list ./... | grep -v vendor` | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
+if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
+    exit $GO_TEST_EXIT_CODE
+fi
+
+echo "Running validation scripts..."
+scripts=(
+    "hack/boilerplate.sh"
+    "hack/gofmt.sh"
+    # "hack/linter.sh"  # TODO(aaron-prindle) lint codebase and add this back
+    "hack/dep.sh"
+)
+fail=0
+for s in "${scripts[@]}"
+do
+    echo "RUN ${s}"
+    set +e
+    ./$s
+    result=$?
+    set -e
+    if [[ $result  -eq 1 ]]; then
+        echo -e "${RED}FAILED${RESET} ${s}"
+        fail=1
+    else
+        echo -e "${GREEN}PASSED${RESET} ${s}"
+    fi
+done
+exit $fail

--- a/test/controller.go
+++ b/test/controller.go
@@ -36,7 +36,7 @@ const (
 )
 
 // WaitForReconcile will wait for the reconcile request to be received on channel c or for a timeout to occur.
-// If the request it recieved it will assert that the request is the expectedRequest.
+// If the request it received it will assert that the request is the expectedRequest.
 func WaitForReconcile(t *testing.T, c chan reconcile.Request, expectedRequest reconcile.Request) {
 	t.Helper()
 

--- a/test/yamlsamples.go
+++ b/test/yamlsamples.go
@@ -68,7 +68,7 @@ func DecodeTypeFromYamlSample(fileName string, intoObj k8sruntime.Object) error 
 	}
 
 	decode := scheme.Codecs.UniversalDeserializer().Decode
-	_, _, err = decode([]byte(yaml), nil, intoObj)
+	_, _, err = decode(yaml, nil, intoObj)
 	if err != nil {
 		return fmt.Errorf("error decoding the file at %s: %s", path, err)
 	}


### PR DESCRIPTION
This PR adds common boilerplate checking, linting, gofmt, and dep fixing scripts to our tests.  I have disabled the linting from being run as I was getting errors with _wasm files.  I believe it is related to this:
https://github.com/golangci/golangci-lint/issues/206 although I was still experiencing the issue after updating and have disabled linting for now.