### PR TITLE
Add CONTRIBUTING.md and code-of-conduct.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to Pipeline CRD
+
+Welcome to the Pipeline CRD project! Thanks for considering contributing to our project and we hope you'll enjoy it :D
+
+**All contributors must comply with [the code of conduct](./code-of-condut.md).**
+
+To get started developing, see our [DEVELOPMENT.md](./DEVELOPMMENT.md).
+
+In this file you'll find info on:
+
+* [Principles](#principles)
+* [The pull request process](#pull-request-process)
+* [Commit message requirements](#commit-messages)
+* [The roadmap and contributions wanted](#roadmap-and-contributions-wanted)
+* [Contacting other contributors](#contact)
+
+_See also [the contribution guidelines for Knative](https://github.com/knative/docs/blob/master/community/CONTRIBUTING.md)._
+
+## Principles
+
+When possbile, try to practice:
+
+* **Documentation driven development** - Before implementing anything, write docs to explain
+  how it will work
+* **Test drivent development** - Before implementing anything, write tests to cover it
+
+Minimize the number of integration tests written and maximize the unit tests! Unit test
+coverage should increase or stay the same with every PR.
+
+This means that most PRs should include both:
+
+* Tests
+* Documentation explaining features being added, including updates to [DEVELOPMENT.md](./DEVELOPMENT.md) if required
+
+## Pull Request Process
+
+This repo uses [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)
+and related tools like [Tide](https://github.com/kubernetes/test-infra/tree/master/prow/tide)
+and [Gubernator](https://github.com/kubernetes/test-infra/tree/master/gubernator)
+(see [Knative Prow](https://github.com/knative/test-infra/blob/master/ci/prow/prow_setup.md)).
+This means that automation will be applied to your pull requests.
+
+Prow has a [number of commands](https://prow.knative.dev/command-help) you can use to interact with it,
+in particular:
+
+* Before a PR can be merged, an owner must approve it with both `/lgtm` AND `/approve`
+* If you don't a PR to be merged, e.g. so that the author can make changes, you can put it on hold with `/hold`
+* When tests (run by Prow) fail, it will add a comment to the PR with the commands to re-run any failing tests
+* You can add dog and cat pictures with `/woof` and `/meow`
+
+Any changes will cause the `/lgtm` label to be removed and it will need to be re-applied.
+
+_See also [Knative docs on reviewing](https://github.com/knative/docs/blob/master/community/REVIEWING.md)._
+
+## Commit Messagse
+
+All commit messages should follow [these best practices](https://chris.beams.io/posts/git-commit/),
+specifically:
+
+* Start with a subject line
+* Contain a body that explains _why_ you're making the change you're making
+
+Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
+Not sure what to put? Include:
+
+* What is the problem being solved?
+* Why is this the best approach?
+* What other approaches did you consider?
+* What side effects will this approach have?
+* What future work remains to be done?
+
+## Roadmap and contributions
+
+As of Sept 2018, our roadmap for the next few months is to:
+
+1. Soldify the API, including:
+
+   * [Designing conditional execution](https://github.com/knative/build-pipeline/issues/27)
+   * [Designing sources](https://github.com/knative/build-pipeline/issues/13)
+   * [Ensuring the the same inputs/outputs are used throughout the pipeline](https://github.com/knative/build-pipeline/issues/11)
+   * [Design references between objects](https://github.com/knative/build-pipeline/issues/38)
+   * [Design templating](https://github.com/knative/build-pipeline/issues/36)
+   * [Design results](https://github.com/knative/build-pipeline/issues/37)
+
+2. Complete a user study (see issues labeled with [user-study](https://github.com/knative/build-pipeline/issues?q=is%3Aissue+is%3Aopen+label%3Auser-study))
+
+3. [Create an initial POC command line tool for interacting with Pipelines](https://github.com/knative/build-pipeline/issues/35)
+
+### Contributions wanted
+
+* To find issues that we particularly would like contributors to tackle, look for
+  [issues with the "help wanted" label](https://github.com/knative/build-pipeline/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+* Issues that are good for new folks will additionally be marked with
+  ["good first issue"](https://github.com/knative/build-pipeline/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+
+### Project board
+
+Our project board is available at: https://github.com/knative/build-pipeline/projects/1
+The columns on the board are:
+
+* Ice box: Work we would like to do, but don't plan to tackle in the next couple weeks
+* Blocked: Issues that are blocked by other tasks
+
+## Contact
+
+This work is being done by
+[the Build CRD working group](https://github.com/knative/docs/blob/master/community/WORKING-GROUPS.md#build).
+If you are interested please join our meetings and or slack!
+
+All docs shared with this group are made visible to members of
+[knative-dev@](https://groups.google.com/forum/#!forum/knative-dev), please join if you are interested!

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by contacting the project team at
+knative-code-of-conduct@googlegroups.com. All complaints will be reviewed
+and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of
+an incident.  Further details of specific enforcement policies may be
+posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+


### PR DESCRIPTION
The contributing.md includes info on how pull requests work
(e.g. prow commands post #41), principles around including
tests, docs, and commit messages.

It also includes the current state of the roadmap and how
to find issues we'd like contributions on.

The code of conduct is the same code of conduct used by the
rest of the knative projects.