### PR TITLE
fix presubmit-test.sh script for

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -23,6 +23,11 @@ function build_tests() {
 
 function unit_tests() {
   echo "Running unit tests"
+  export version=1.0.0
+  export arch=amd64
+  curl -LO https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz
+  tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz
+  mv kubebuilder_${version}_linux_${arch} /usr/local/kubebuilder
   make test
 }
 


### PR DESCRIPTION
currently the presubmit-test.sh script for prow is failing as we have a dependency on kubebuilder in our tests that prow does not have.  this adds a kubebuilder install to the test, we can alternatively add this dependency in knative/test-infra to our test container.