### PR TITLE
Add issue number to commit message requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,8 @@ specifically:
 
 * Start with a subject line
 * Contain a body that explains _why_ you're making the change you're making
+* Reference an issue number one exists, closing it if applicable (with text such as
+  ["Fixes #245" or "Closes #111"](https://help.github.com/articles/closing-issues-using-keywords/))
 
 Aim for [2 paragraphs in the body](https://www.youtube.com/watch?v=PJjmw9TRB7s).
 Not sure what to put? Include:


### PR DESCRIPTION
Not every commit message will have an issue number associated with it,
(this one doesn't! hah!) but if it does, it should reference that issue
number somewhere in the body, and if the commit resolves the issue,
take advantage of GithHub's automation to automatically link the two
and resolve the issue.