### PR TITLE
Run integration tests on presubmit using boskos (from prow) or kubetest (locally) or an existing cluster

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,10 +89,9 @@ kubectl create clusterrolebinding cluster-admin-binding \
 
 ## Deploy Knative Build
 
-build-pipeline has a dependency on [build](https://github.com/knative/build)
 
 ```
-kubectl deploy -f ./third_party/config/build/release.yaml
+kubectl apply -f ./third_party/config/build/release.yaml
 ```
 
 ## Iterating
@@ -116,11 +115,12 @@ To make changes to these CRDs, you will probably interact with:
 
 ## Running everything
 
-You can stand up a version of this controller on-cluster (to your `kubectl config current-context`) with:
+You can stand up a version of this controller on-cluster (to your `kubectl config current-context`),
+including `knative/build` (which is wrapped by [`Task`](README.md#task)):
 
 ```shell
-# This will register the CRD and deploy the controller to start acting on them.
 ko apply -f config/
+kubectl deploy -f ./third_party/config/build/release.yaml
 ```
 
 As you make changes to the code, you can redeploy your controller with:
@@ -133,7 +133,9 @@ You can clean up everything with:
 
 ```shell
 ko delete -f config/
+kubectl delete -f ./third_party/config/build/release.yaml
 ```
+
 ## Accessing logs
 
 To look at the controller logs, run:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,11 +200,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2ee94e6988f348c1c6bd0393d8093b4262dbe95f8635f5b59ee211ec1ff66837"
+  digest = "1:e2b69720fb704bbd32b9440b9a74f3be9e8b5ab7879281c69981f51c6ae40e35"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "dc3a4e38d9f942d3df262e5b6b59a8e61c15ed15"
+  revision = "13055d769cc5e1756e605fcb3bcc1c25376699f1"
 
 [[projects]]
   branch = "master"

--- a/test/README.md
+++ b/test/README.md
@@ -175,4 +175,37 @@ You can run this locally with:
 
 ```shell
 test/presubmit-tests.sh
+test/presubmit-tests.sh --build-tests
+test/presubmit-tests.sh --unit-tests
+```
+
+Prow is configured in [the knative `config.yaml` in `knative/test-infra`](https://github.com/knative/test-infra/blob/master/ci/prow/config.yaml)
+via the sections for `knative/build-pipeline`.
+
+### Running presubmit integration tests
+
+When run using Prow, integration tests will try to get a new cluster using [boskos](https://github.com/kubernetes/test-infra/tree/master/boskos) and
+[these hardcoded GKE projects](https://github.com/knative/test-infra/blob/master/ci/prow/boskos/resources.yaml#L15),
+which only [the `knative/test-infra` OWNERS](https://github.com/knative/test-infra/blob/master/OWNERS)
+have access to.
+
+If you would like to run the integration tests against your cluster, you can use the
+`K8S_CLUSTER_OVERRIDE` environment variable to force the scripts to use your own cluster,
+and provide `KO_DOCKER_REPO` (as specified in the [DEVELOPMENT.md](../DEVELOPMENT.md#environment-setup)):
+
+```shell
+export K8S_CLUSTER_OVERRIDE=my_k8s_cluster # corresponds to a `context` in your kubeconfig
+export KO_DOCKER_REPO=gcr.io/my_docker_repo # required for deployments using `ko`
+test/presubmit-tests.sh --integration-tests
+```
+
+Or you can set `$PROJECT_ID` to a GCP project and rely on
+[kubetest](https://github.com/kubernetes/test-infra/tree/master/kubetest)
+to setup a cluster for you:
+
+```shell
+export K8S_CLUSTER_OVERRIDE=
+export PROJECT_ID=my_gcp_project
+export KO_DOCKER_REPO=gcr.io/my_docker_repo # required for deployments using `ko`
+test/presubmit-tests.sh --integration-tests
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -191,12 +191,13 @@ have access to.
 
 If you would like to run the integration tests against your cluster, you can use the
 `K8S_CLUSTER_OVERRIDE` environment variable to force the scripts to use your own cluster,
-and provide `KO_DOCKER_REPO` (as specified in the [DEVELOPMENT.md](../DEVELOPMENT.md#environment-setup)):
+provide `KO_DOCKER_REPO` (as specified in the [DEVELOPMENT.md](../DEVELOPMENT.md#environment-setup)),
+use `e2e-tests.sh` directly and provide the `--run-tests` argument:
 
 ```shell
 export K8S_CLUSTER_OVERRIDE=my_k8s_cluster # corresponds to a `context` in your kubeconfig
 export KO_DOCKER_REPO=gcr.io/my_docker_repo # required for deployments using `ko`
-test/presubmit-tests.sh --integration-tests
+test/e2e-tests.sh --run-tests
 ```
 
 Or you can set `$PROJECT_ID` to a GCP project and rely on

--- a/test/cluster-setup.sh
+++ b/test/cluster-setup.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script calls out to scripts in knative/test-infra to setup a cluster
+# and deploy the Pipeline CRD to it for running integration tests.
+
+source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+
+function take_down_pipeline() {
+    header "Tearing down Pipeline CRD"
+    ko delete --ignore-not-found=true -f config/
+}
+trap take_down_pipeline EXIT
+
+# Called by `fail_test` (provided by `e2e-tests.sh`) to dump info on test failure
+function dump_extra_cluster_state() {
+  for crd in pipelines pipelineruns tasks taskruns resources pipelineparams
+  do
+    echo ">>> $crd:"
+    kubectl get $crd -o yaml --all-namespaces
+  done
+  echo ">>> Pipeline controller log:"
+  kubectl -n knative-build-pipeline logs $(get_app_pod build-pipeline-controller knative-build-pipeline)
+  echo ">>> Pipeline webhook log:"
+  kubectl -n knative-build-pipeline logs $(get_app_pod build-pipeline-webhook knative-build-pipeline)
+}
+
+set +o xtrace
+header "Setting up environment"
+# The intialize method will attempt to create a new cluster in $PROJECT_ID unless
+# the `--run-tests` parameter is provided and `K8S_CLUSTER_OVERRIDE` is set, however
+# since knative/test-infra/scripts/presubmit-tests.sh doesn't propagate `--run-tests`
+# (and it's kind of a confusing param name), we'll infer it from the presence of
+# `K8S_CLUSTER_OVERRIDE`
+if [[ -z ${K8S_CLUSTER_OVERRIDE} ]]; then
+    initialize
+else
+    initialize --run-tests
+fi
+set -o xtrace
+
+# The scripts were initially setup to use the knative/serving style `DOCKER_REPO_OVERRIDE`
+# before knative/serving was updated to use `ko` + `KO_DOCKER_REPO`. If the scripts were
+# called with `KO_DOCKER_REPO` already set (i.e. using a user's own local cluster, we should
+# respect that).
+if ! [[ -z ${KO_DOCKER_REPO} ]]; then
+    export DOCKER_REPO_OVERRIDE=${KO_DOCKER_REPO}
+fi
+
+# Deploy the latest version of the Pipeline CRD.
+# TODO(#59) do we need to deploy the Build CRD as well?
+header "Deploying Pipeline CRD"
+ko apply -f config/
+
+# Wait for pods to be running in the namespaces we are deploying to
+set +o xtrace
+wait_until_pods_running knative-build-pipeline || fail_test "Pipeline CRD did not come up"
+set -o xtrace

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -73,6 +73,7 @@ func tearDownMain(kubeClient *knativetest.KubeClient, logger *logging.BaseLogger
 func TestMain(m *testing.M) {
 	initializeLogsAndMetrics()
 	logger := logging.GetContextLogger("TestMain")
+	logger.Infof("Using kubeconfig at `%s` with cluster `%s`", knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster)
 
 	namespace = AppendRandomString("arendelle")
 	kubeClient := createNamespace(namespace, logger)

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -52,20 +52,9 @@ function integration_tests() {
   # this from Prow we need to provide our own.
   export BUILD_NUMBER=${BUILD_NUMBER:-$RANDOM}
 
-  # Use knative test-infra scripts to make `fail-test` and `success` available.
-  # which will output helpful information for debugging failures, and ensure test
-  # results are made available.
-  source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
-  # Setup the cluster (if not using an existing cluster) and deploy the Pipeline CRD
-  source $(dirname $0)/cluster-setup.sh
-
   options=""
   (( EMIT_METRICS )) && options="-emitmetrics"
-  report_go_test \
-    -v -tags=e2e -count=1 -timeout=20m ./test \
-    ${options} || fail_test
-
-  success
+   ./test/e2e-tests.sh ${options}
 }
 
 main $@

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 # This script runs the presubmit tests; it is started by prow for each PR.
+# When running `--integration-tests`, use `K8S_CLUSTER_OVERRIDE` to point at your
+# own cluster (a context in your kubeconfig), or the script will attempt to invoke
+# boskos to obtain one of the knative testing clusters in GKE.
 
 set -o xtrace
 
@@ -43,7 +46,26 @@ function unit_tests() {
 
 function integration_tests() {
   echo "Running integration tests"
-  echo "TODO(#16): add integration tests"
+
+  # The logic to create resource names (which are used by kubetest) in `e2e-tests.sh` requires
+  # that the variable `BUILD_NUMBER` be set, which is provided by Prow, so if we aren't running
+  # this from Prow we need to provide our own.
+  export BUILD_NUMBER=${BUILD_NUMBER:-$RANDOM}
+
+  # Use knative test-infra scripts to make `fail-test` and `success` available.
+  # which will output helpful information for debugging failures, and ensure test
+  # results are made available.
+  source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+  # Setup the cluster (if not using an existing cluster) and deploy the Pipeline CRD
+  source $(dirname $0)/cluster-setup.sh
+
+  options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test \
+    -v -tags=e2e -count=1 -timeout=20m ./test \
+    ${options} || fail_test
+
+  success
 }
 
 main $@

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -1,3 +1,62 @@
 # Helper scripts
 
-This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+This directory contains helper scripts used by Prow test jobs, as well and
+local development scripts.
+
+## Using the `e2e-tests.sh` helper script
+
+This is a helper script for Knative E2E test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `teardown()` function, which will tear down your test
+resources.
+
+1. [optional] Write the `dump_extra_cluster_state()` function. It will be
+called when a test fails, and can dump extra information about the current state
+of the cluster (tipically using `kubectl`).
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
+(or `report_go_test()` if you need a more fine-grained control) and call
+`fail_test()` or `success()` if any of them failed. The environment variables
+`DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be set
+according to the test cluster. You can also use the following boolean (0 is false,
+1 is true) environment variables for the logic:
+  * `EMIT_METRICS`: true if `--emit-metrics` is passed.
+  * `USING_EXISTING_CLUSTER`: true if the test cluster is an already existing one,
+and not a temporary cluster created by `kubetest`.
+All environment variables above are marked read-only.
+
+**Notes:**
+
+1. Calling your script without arguments will create a new cluster in the GCP
+project `$PROJECT_ID` and run the tests against it.
+
+1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
+`K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+tests against the cluster.
+
+### A minimal end-to-end script runner
+
+This script will test that the latest Knative Serving nightly release works.
+
+```
+source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+function teardown() {
+  echo "TODO: tear down test resources"
+}
+
+initialize $@
+
+start_latest_knative_serving
+
+wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+
+# TODO: use go_test_e2e to run the tests.
+kubectl get pods || fail_test
+
+success
+```

--- a/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
@@ -14,30 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script for Knative E2E test scripts. To use it:
-# 1. Source this script.
-# 2. [optional] Write the teardown() function, which will tear down your test
-#    resources.
-# 3. [optional] Write the dump_extra_cluster_state() function. It will be called
-#    when a test fails, and can dump extra information about the current state of
-#    the cluster (tipically using kubectl).
-# 4. Call the initialize() function passing $@ (without quotes).
-# 5. Write logic for the end-to-end tests. Run all go tests using report_go_test()
-#    and call fail_test() or success() if any of them failed. The envitronment
-#    variables DOCKER_REPO_OVERRIDE, K8S_CLUSTER_OVERRIDE and K8S_USER_OVERRIDE
-#    will be set accordingly to the test cluster. You can also use the following
-#    boolean (0 is false, 1 is true) environment variables for the logic:
-#    EMIT_METRICS: true if --emit-metrics is passed.
-#    USING_EXISTING_CLUSTER: true if the test cluster is an already existing one,
-#                            and not a temporary cluster created by kubetest.
-#    All environment variables above are marked read-only.
-# Notes:
-# 1. Calling your script without arguments will create a new cluster in the GCP
-#    project $PROJECT_ID and run the tests against it.
-# 2. Calling your script with --run-tests and the variables K8S_CLUSTER_OVERRIDE,
-#    K8S_USER_OVERRIDE and DOCKER_REPO_OVERRIDE set will immediately start the
-#    tests against the cluster.
-
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Build a resource name based on $E2E_BASE_NAME, a suffix and $BUILD_NUMBER.
@@ -91,6 +67,14 @@ function fail_test() {
   exit 1
 }
 
+# Run the given E2E tests (must be tagged as such).
+# Parameters: $1..$n - directories containing the tests to run.
+function go_test_e2e() {
+  local options=""
+  (( EMIT_METRICS )) && options="-emitmetrics"
+  report_go_test -v -tags=e2e -count=1 -timeout=20m $@ ${options}
+}
+
 # Download the k8s binaries required by kubetest.
 function download_k8s() {
   local version=${SERVING_GKE_VERSION}
@@ -109,9 +93,6 @@ function download_k8s() {
     return 1
   fi
   # Download k8s to staging dir
-  if [[ -z "${GOPATH}" ]]; then
-    local GOPATH=$(go env GOPATH)
-  fi
   version=v${version}
   local staging_dir=${GOPATH}/src/k8s.io/kubernetes/_output/gcs-stage
   rm -fr ${staging_dir}
@@ -155,6 +136,10 @@ function dump_cluster_state() {
 
 # Create a test cluster with kubetest and call the current script again.
 function create_test_cluster() {
+  # Fail fast during setup.
+  set -o errexit
+  set -o pipefail
+
   header "Creating test cluster"
   # Smallest cluster required to run the end-to-end-tests
   local CLUSTER_CREATION_ARGS=(
@@ -174,6 +159,7 @@ function create_test_cluster() {
   fi
   # SSH keys are not used, but kubetest checks for their existence.
   # Touch them so if they don't exist, empty files are create to satisfy the check.
+  mkdir -p $HOME/.ssh
   touch $HOME/.ssh/google_compute_engine.pub
   touch $HOME/.ssh/google_compute_engine
   # Clear user and cluster variables, so they'll be set to the test cluster.
@@ -190,6 +176,9 @@ function create_test_cluster() {
   (( EMIT_METRICS )) && test_cmd_args+=" --emit-metrics"
   echo "Test script is ${E2E_SCRIPT}"
   download_k8s || return 1
+  # Don't fail test for kubetest, as it might incorrectly report test failure
+  # if teardown fails (for details, see success() below)
+  set +o errexit
   kubetest "${CLUSTER_CREATION_ARGS[@]}" \
     --up \
     --down \
@@ -198,6 +187,8 @@ function create_test_cluster() {
     --test-cmd "${E2E_SCRIPT}" \
     --test-cmd-args "${test_cmd_args}"
   echo "Test subprocess exited with code $?"
+  # Ignore any errors below, this is a best-effort cleanup and shouldn't affect the test result.
+  set +o errexit
   # Delete target pools and health checks that might have leaked.
   # See https://github.com/knative/serving/issues/959 for details.
   # TODO(adrcunha): Remove once the leak issue is resolved.

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -65,6 +65,19 @@ function exit_if_presubmit_not_required() {
 function main() {
   exit_if_presubmit_not_required
 
+  # Show the version of the tools we're using
+  if (( IS_PROW )); then
+    # Disable gcloud update notifications
+    gcloud config set component_manager/disable_update_check true
+    header "Current test setup"
+    echo ">> gcloud SDK version"
+    gcloud version
+    echo ">> kubectl version"
+    kubectl version
+    echo ">> go version"
+    go version
+  fi
+
   local all_parameters=$@
   [[ -z $1 ]] && all_parameters="--all-tests"
 


### PR DESCRIPTION
Using the scripts from knative/test-infra, run the integration tests
against a cluster created with boskos. A lot of the boskos stuff is
still kind of magical, for example I have no idea what is controlling
the $PROJECT_ID that is being used by knative projects on presubmit, but
after wrestling with it a bit and hacking around `--run-tests` I was
able to get it to work locally and deploy a cluster (I assume using
boskos?). I'll follow up on this more later on and update the docs when
I have more info.

Assuming we can get https://github.com/knative/test-infra/pull/169
merged I'll revert the change to `e2e-tests.sh` in the `vendor` dir.

Fixes #16