### PR TITLE
Add badge to README for integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Pipeline CRD
 
+[![Prow integration test results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-integration-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-integration-tests)
 [![Prow unit test results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-unit-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-unit-tests)
 [![Prow build results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-build-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-build-tests)
 [![Go Report Card](https://goreportcard.com/badge/knative/build-pipeline)](https://goreportcard.com/report/knative/build-pipeline)


### PR DESCRIPTION
Integration tests were added as part of #16 

Upside: another badge!
Downside: badge doesn't look good at all XD

![image](https://user-images.githubusercontent.com/432502/46505762-ff093880-c7e6-11e8-8c47-70631b7d1d66.png)

Looks like we're still hitting https://github.com/kubernetes/test-infra/issues/9628 so if anyone is looking for a break from build-pipeline that would be super helpful to fix XD