### PR TITLE
Add actual validation to the task validation webhook skeleton.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -36,6 +36,8 @@ const (
 	PipelineResourceTypeImage PipelineResourceType = "image"
 )
 
+var AllResourceTypes = []PipelineResourceType{PipelineResourceTypeGit, PipelineResourceTypeGCS, PipelineResourceTypeImage}
+
 // PipelineResourceInterface interface to be implemented by different PipelineResource types
 type PipelineResourceInterface interface {
 	GetName() string

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+)
+
+var validSource = Source{
+	Name: "source",
+	Type: "git",
+}
+
+func TestTaskSpec_Validate(t *testing.T) {
+	type fields struct {
+		Inputs    *Inputs
+		Outputs   *Outputs
+		BuildSpec *buildv1alpha1.BuildSpec
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "valid inputs",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{validSource},
+				},
+			},
+		},
+		{
+			name: "valid outputs",
+			fields: fields{
+				Outputs: &Outputs{
+					Sources: []Source{validSource},
+				},
+			},
+		},
+		{
+			name: "both valid",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{validSource},
+				},
+				Outputs: &Outputs{
+					Sources: []Source{validSource},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := &TaskSpec{
+				Inputs:    tt.fields.Inputs,
+				Outputs:   tt.fields.Outputs,
+				BuildSpec: tt.fields.BuildSpec,
+			}
+			if err := ts.Validate(); err != nil {
+				t.Errorf("TaskSpec.Validate() = %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskSpec_ValidateError(t *testing.T) {
+	type fields struct {
+		Inputs    *Inputs
+		Outputs   *Outputs
+		BuildSpec *buildv1alpha1.BuildSpec
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "one invalid input",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{
+						{
+							Name: "source",
+							Type: "what",
+						},
+						validSource,
+					},
+				},
+				Outputs: &Outputs{
+					Sources: []Source{
+						validSource,
+					},
+				},
+			},
+		},
+		{
+			name: "one invalid output",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{
+						validSource,
+					},
+				},
+				Outputs: &Outputs{
+					Sources: []Source{
+						{
+							Name: "who",
+							Type: "what",
+						},
+						validSource,
+					},
+				},
+			},
+		},
+		{
+			name: "duplicated inputs",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{
+						validSource,
+						validSource,
+					},
+				},
+				Outputs: &Outputs{
+					Sources: []Source{
+						validSource,
+					},
+				},
+			},
+		},
+		{
+			name: "duplicated outputs",
+			fields: fields{
+				Inputs: &Inputs{
+					Sources: []Source{
+						validSource,
+					},
+				},
+				Outputs: &Outputs{
+					Sources: []Source{
+						validSource,
+						validSource,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := &TaskSpec{
+				Inputs:    tt.fields.Inputs,
+				Outputs:   tt.fields.Outputs,
+				BuildSpec: tt.fields.BuildSpec,
+			}
+			if err := ts.Validate(); err == nil {
+				t.Errorf("TaskSpec.Validate() did not return error.")
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -19,12 +19,23 @@ package v1alpha1
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 )
 
-var validSource = Source{
+var validResource = TaskResource{
 	Name: "source",
 	Type: "git",
+}
+
+var validBuild = &buildv1alpha1.BuildSpec{
+	Steps: []corev1.Container{
+		{
+			Name:  "mystep",
+			Image: "myimage",
+		},
+	},
 }
 
 func TestTaskSpec_Validate(t *testing.T) {
@@ -41,27 +52,30 @@ func TestTaskSpec_Validate(t *testing.T) {
 			name: "valid inputs",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{validSource},
+					Resources: []TaskResource{validResource},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 		{
 			name: "valid outputs",
 			fields: fields{
 				Outputs: &Outputs{
-					Sources: []Source{validSource},
+					Resources: []TaskResource{validResource},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 		{
 			name: "both valid",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{validSource},
+					Resources: []TaskResource{validResource},
 				},
 				Outputs: &Outputs{
-					Sources: []Source{validSource},
+					Resources: []TaskResource{validResource},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 	}
@@ -93,72 +107,95 @@ func TestTaskSpec_ValidateError(t *testing.T) {
 			name: "nil",
 		},
 		{
+			name: "no build",
+			fields: fields{
+				Inputs: &Inputs{
+					Resources: []TaskResource{validResource},
+				},
+			},
+		},
+		{
 			name: "one invalid input",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{
+					Resources: []TaskResource{
 						{
 							Name: "source",
 							Type: "what",
 						},
-						validSource,
+						validResource,
 					},
 				},
 				Outputs: &Outputs{
-					Sources: []Source{
-						validSource,
+					Resources: []TaskResource{
+						validResource,
 					},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 		{
 			name: "one invalid output",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{
-						validSource,
+					Resources: []TaskResource{
+						validResource,
 					},
 				},
 				Outputs: &Outputs{
-					Sources: []Source{
+					Resources: []TaskResource{
 						{
 							Name: "who",
 							Type: "what",
 						},
-						validSource,
+						validResource,
 					},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 		{
 			name: "duplicated inputs",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{
-						validSource,
-						validSource,
+					Resources: []TaskResource{
+						validResource,
+						validResource,
 					},
 				},
 				Outputs: &Outputs{
-					Sources: []Source{
-						validSource,
+					Resources: []TaskResource{
+						validResource,
 					},
 				},
+				BuildSpec: validBuild,
 			},
 		},
 		{
 			name: "duplicated outputs",
 			fields: fields{
 				Inputs: &Inputs{
-					Sources: []Source{
-						validSource,
+					Resources: []TaskResource{
+						validResource,
 					},
 				},
 				Outputs: &Outputs{
-					Sources: []Source{
-						validSource,
-						validSource,
+					Resources: []TaskResource{
+						validResource,
+						validResource,
 					},
+				},
+				BuildSpec: validBuild,
+			},
+		},
+		{
+			name: "invalid build",
+			fields: fields{
+				Inputs: &Inputs{
+					Resources: []TaskResource{validResource},
+				},
+				BuildSpec: &buildv1alpha1.BuildSpec{
+					Steps: []corev1.Container{},
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds the following validation:
- Task inputs and outputs must have a valid Type
- Task inputs and outputs must not have a duplicated name.

Ref #29 