### PR TITLE
Add an error check and logging for webhook server startup.

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -91,5 +91,7 @@ func main() {
 	if err != nil {
 		logger.Fatal("Failed to create the admission controller", zap.Error(err))
 	}
-	controller.Run(stopCh)
+	if err := controller.Run(stopCh); err != nil {
+		logger.Fatal("Error running admission controller", zap.Error(err))
+	}
 }


### PR DESCRIPTION
Without this the webhook server can crash silently if an error is returned.