### PR TITLE
Remove badges until red status is fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Pipeline CRD
 
-[![Prow integration test results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-integration-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-integration-tests)
-[![Prow unit test results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-unit-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-unit-tests)
-[![Prow build results](https://prow.knative.dev/badge.svg?jobs=pull-knative-build-pipeline-build-tests)](https://prow.knative.dev/?job=pull-knative-build-pipeline-build-tests)
 [![Go Report Card](https://goreportcard.com/badge/knative/build-pipeline)](https://goreportcard.com/report/knative/build-pipeline)
 
 This repo contains the API definition of the Pipeline CRD and an on cluster implementation of that API.


### PR DESCRIPTION
Since https://github.com/kubernetes/test-infra/issues/9628 isn't yet
fixed, the badges are all red even though the most recent runs were
successful.

Even once that is fixed, the badges could still become red from failure
on PRs.

Removing for now since they are making us look bad for no good reason XD

At least we still get the report card:
![image](https://user-images.githubusercontent.com/432502/46703535-48d59280-cbdc-11e8-86c2-b89cb93546d5.png)
