### PR TITLE
Disallow Tasks to specify BuildSpecs that use BuildTemplates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ High level details of this design:
 ### Task
 
 `Task` is a CRD that knows how to instantiate a [Knative Build](https://github.com/knative/build),
-either from a series of `steps` (i.e. [Builders](https://github.com/knative/docs/blob/master/build/builder-contract.md))
-or from a [`BuildTemplate`](https://github.com/knative/docs/blob/master/build/build-templates.md).
+either from a series of `steps` (i.e. [Builders](https://github.com/knative/docs/blob/master/build/builder-contract.md)).
 It takes Knative Build and adds inputs and outputs. Where these inputs and outputs are provided
 from is not known to a task, so they can be provided by a Pipeline or by a user invoking a Task directly.
 
 `Tasks` are basically [Knative BuildTemplates](https://github.com/knative/build-templates)
 with additional input types and clearly defined outputs.
+This means that `Tasks` must refer to `Builds`, not `BuildTemplates`.
 
 See [docs/task-parameters.md](./docs/task-parameters.md) for how to use parameters with Tasks.
 

--- a/docs/pipeline-resources.md
+++ b/docs/pipeline-resources.md
@@ -39,22 +39,20 @@ metadata:
 spec:
     inputs:
         resources:
-           - name: wizzbang-git
-             type: git
+        - name: wizzbang-git
+          type: git
         params:
-           - name: PATH_TO_DOCKERFILE
-             value: string
+        - name: pathToDockerfile
+          value: string
     outputs:
         resources:
           - name: builtImage 
     buildSpec:
-        template:
-            name: kaniko
-            arguments:
-                - name: DOCKERFILE
-                  value: ${PATH_TO_DOCKERFILE}
-                - name: REGISTRY
-                  value: ${REGISTRY}
+        steps:
+        - name: build-and-push
+          image: gcr.io/my-repo/my-imageg
+          args:
+          - --repo=${inputs.resources.wizzbang-git.url}
 ``` 
 
  #### And finally set the version in the `TaskRun` definition
@@ -71,7 +69,7 @@ spec:
     inputs:
         resourcesVersion:
           - resourceRef:
-              name: wizzbang-git
+            name: wizzbang-git
             version: HEAD
     outputs:
         artifacts:

--- a/examples/build_task.yaml
+++ b/examples/build_task.yaml
@@ -15,10 +15,9 @@ spec:
             - name: builtImage
               type: image
     buildSpec:
-        template:
-            name: kaniko
-            arguments:
-                - name: DOCKERFILE
-                  value: ${pathToDockerFile}
-                - name: REGISTRY
-                  value: ${registry}
+          steps:
+          - name: build-and-push
+            image: gcr.io/kaniko-project/executor
+            args:
+            - --dockerfile=${pathToDockerFile}
+            - --destination=$builtImage

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -44,6 +44,11 @@ func (ts *TaskSpec) Validate() *apis.FieldError {
 		return err
 	}
 
+	// We also require that a BuildSpec is NOT a template.
+	if ts.BuildSpec.Template != nil {
+		return apis.ErrDisallowedFields("taskspec.BuildSpec.Template")
+	}
+
 	// A task doesn't have to have inputs or outputs, but if it does they must be valid.
 	// A task can't duplicate input or output names.
 

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -199,6 +199,16 @@ func TestTaskSpec_ValidateError(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "build template invalid",
+			fields: fields{
+				BuildSpec: &buildv1alpha1.BuildSpec{
+					Template: &buildv1alpha1.TemplateInstantiationSpec{
+						Name: "foo",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This will make it easier for us to append/prepend steps to the builds we generate.
We could relax this in the long-term by dereferencing the buildspec ourselves, or
using a MutatingAdmissionWebhook to change the Build/Pod as they are created.