### PR TITLE
Remove Service Account from PipelineResource definition

### DIFF
--- a/docs/pipeline-resources.md
+++ b/docs/pipeline-resources.md
@@ -21,15 +21,12 @@ spec:
     value: github.com/wizzbangcorp/wizzbang
   - name: Revision
     value: master
-  - name: ServiceAccount
-    value: pipeline-sa    
  ```
 
    Params that can be added are the following:
 
    1. URL: represents the location of the git repository 
    1. Revision: Git [revision](https://git-scm.com/docs/gitrevisions#_specifying_revisions ) (branch, tag, commit SHA or ref) to clone. If no revision is specified, the resource will default to `latest` from `master`
-   1. Service Account: specifies the `name` of a `ServiceAccount` resource object. Add this paramater to run your task with the privileges of the specified service account. If no serviceAccountName field is specified, your task runs using the default service account that is in the namespace of the Pipeline resource object.  
 
  #### Use the defined git resource in a `Task` definition
 

--- a/examples/pipelines/guestbook-resources.yaml
+++ b/examples/pipelines/guestbook-resources.yaml
@@ -10,8 +10,6 @@ spec:
       value: github.com/kubernetes/examples
     - name: revision
       value: HEAD      
-    - name: serviceAccount
-      value: githubServiceAccount
 ---      
 apiVersion: pipeline.knative.dev/v1alpha1
 kind: Resource
@@ -23,8 +21,6 @@ spec:
     params:
       - name: url
         value: github.com/GoogleCloudPlatform/redis-docker/
-      - name: serviceAccount
-        value: githubServiceAccount
       - name: revision
         value: HEAD
 ---        

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -31,8 +31,6 @@ type GitResource struct {
 	// https://git-scm.com/docs/gitrevisions#_specifying_revisions for more
 	// information.
 	Revision string `json:"revision"`
-	// +optional
-	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // NewGitResource create a new git resource to pass to Knative Build
@@ -48,8 +46,6 @@ func NewGitResource(r *PipelineResource) (*GitResource, error) {
 		switch {
 		case strings.EqualFold(param.Name, "URL"):
 			gitResource.URL = param.Value
-		case strings.EqualFold(param.Name, "serviceAccount"):
-			gitResource.ServiceAccount = param.Value
 		case strings.EqualFold(param.Name, "Revision"):
 			gitResource.Revision = param.Value
 		}
@@ -76,11 +72,6 @@ func (s GitResource) GetType() PipelineResourceType {
 // more details what the revison in github is
 func (s GitResource) GetVersion() string {
 	return s.Revision
-}
-
-// GetServiceAccountName returns the service account to be used with this resource
-func (s *GitResource) GetServiceAccountName() string {
-	return s.ServiceAccount
 }
 
 // GetURL returns the url to be used with this resource

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -22,8 +22,6 @@ type ImageResource struct {
 	Type   PipelineResourceType `json:"type"`
 	URL    string               `json:"url"`
 	Digest string               `json:"digest"`
-	// +optional
-	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // GetName returns the name of the resource
@@ -39,11 +37,6 @@ func (s ImageResource) GetType() PipelineResourceType {
 // GetVersion returns the version of the resource
 func (s ImageResource) GetVersion() string {
 	return s.Digest
-}
-
-// GetServiceAccountName returns the service account to be used with this resource
-func (s *ImageResource) GetServiceAccountName() string {
-	return s.ServiceAccount
 }
 
 // GetParams returns the resoruce params

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -44,7 +44,6 @@ type PipelineResourceInterface interface {
 	GetType() PipelineResourceType
 	GetParams() []Param
 	GetVersion() string
-	GetServiceAccountName() string
 }
 
 // PipelineResourceStatus should implment status for PipelineResource

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -54,27 +54,7 @@ func setUp() {
 			},
 		},
 	}
-	resWithServiceAccount := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "workspace-sa",
-			Namespace: "marshmallow",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: "git",
-			Params: []v1alpha1.Param{
-				v1alpha1.Param{
-					Name:  "Url",
-					Value: "https://github.com/grafeas/kritis",
-				},
-				v1alpha1.Param{
-					Name:  "ServiceAccount",
-					Value: "kritis-service-account",
-				},
-			},
-		},
-	}
 	pipelineResourceInformer.Informer().GetIndexer().Add(res)
-	pipelineResourceInformer.Informer().GetIndexer().Add(resWithServiceAccount)
 }
 
 func TestAddResourceToBuild(t *testing.T) {
@@ -277,54 +257,6 @@ func TestAddResourceToBuild(t *testing.T) {
 						Revision: "master",
 					},
 				},
-			},
-		},
-	}, {
-		desc: "set service account if provided",
-		task: &v1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "build-from-repo",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskSpec{
-				Inputs: &v1alpha1.Inputs{
-					Resources: []v1alpha1.TaskResource{
-						v1alpha1.TaskResource{
-							Name: "workspace-sa",
-							Type: "git",
-						},
-					},
-				},
-			},
-		},
-		taskRun: taskRun,
-		build:   build,
-		wantErr: false,
-		want: &buildv1alpha1.Build{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Build",
-				APIVersion: "build.knative.dev/v1alpha1"},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "build-from-repo",
-				Namespace: "marshmallow",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         "pipeline.knative.dev/v1alpha1",
-						Kind:               "TaskRun",
-						Name:               "build-from-repo-run",
-						Controller:         &boolTrue,
-						BlockOwnerDeletion: &boolTrue,
-					},
-				},
-			},
-			Spec: buildv1alpha1.BuildSpec{
-				Source: &buildv1alpha1.SourceSpec{
-					Git: &buildv1alpha1.GitSourceSpec{
-						Url:      "https://github.com/grafeas/kritis",
-						Revision: "master",
-					},
-				},
-				ServiceAccountName: "kritis-service-account",
 			},
 		},
 	}, {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -64,11 +64,6 @@ func AddInputResource(
 	}
 
 	build.Spec.Source = &buildv1alpha1.SourceSpec{Git: gitSourceSpec}
-	// add service account name if available, otherwise Build will
-	// use the default service account in the namespace
-	if gitResource.ServiceAccount != "" {
-		build.Spec.ServiceAccountName = gitResource.ServiceAccount
-	}
 
 	return build, nil
 }


### PR DESCRIPTION
Fixes #126 

## Proposed changes 
 * ServiceAccount is already defined in PipelineParams
 * Build CRD is used for execution of a Task and only support one
   service account for all resources
 * Removed from interface and both git and image resources