### PR TITLE
add log validation to integration tests

### DIFF
--- a/test/crd_checks.go
+++ b/test/crd_checks.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	"go.opencensus.io/trace"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -54,6 +55,23 @@ func WaitForTaskRunState(c *clients, name string, inState func(r *v1alpha1.TaskR
 	})
 }
 
+// WaitForPodState polls the status of the Pod called name from client every
+// interval until inState returns `true` indicating it is done, returns an
+// error or timeout. desc will be used to name the metric that is emitted to
+// track how long it took for name to get into the state checked by inState.
+func WaitForPodState(c *clients, name string, namespace string, inState func(r *corev1.Pod) (bool, error), desc string) error {
+	metricName := fmt.Sprintf("WaitForPodState/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		r, err := c.KubeClient.Kube.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return inState(r)
+	})
+}
 
 // WaitForPipelineRunState polls the status of the PipelineRun called name from client every
 // interval until inState returns `true` indicating it is done, returns an

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -37,7 +37,7 @@ func TestPipelineRun(t *testing.T) {
 	defer tearDown(logger, c.KubeClient, namespace)
 
 	logger.Infof("Creating Pipeline Resources in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(getHelloWorldTask(namespace)); err != nil {
+	if _, err := c.TaskClient.Create(getHelloWorldTask(namespace, []string{"echo", taskOutput})); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", hwTaskName, err)
 	}
 	if _, err := c.PipelineClient.Create(getHelloWorldPipeline(namespace)); err != nil {
@@ -63,4 +63,7 @@ func TestPipelineRun(t *testing.T) {
 	}
 
 	// TODO check that TaskRuns created
+
+	// Verify that the init containers Build ran had 'taskOutput' written
+	// VerifyBuildOutput(t, c, namespace, taskOutput)
 }


### PR DESCRIPTION
What is the problem being solved?
This pr addresses #119 which explains that the integration tests should support viewing the logs for a Build containers invocation.

Why is this the best approach?
The solution to get the logs for Builds in this pr relies on using PersistentVolume's.  A volume is mounted into the test Build, the BuildSpec container writes to the mounted volume, and then a verfication pod is run that also mounts this Persistent volume at which point the Build logs for the init container that Build spawned are now verifiable.

What other approaches did you consider?
- Use Stackdriver logs
Issues:
- Stackdriver can take >30 minutes to propogate logs in some cases so it is not feasible for integration test
- Stackdriver use would limit integration tests to only work on clusters with Stackdriver integration

What side effects will this approach have?
This test will require that all test Tasks that are verifiable only through stdout/logging have to write to disk as that is how we can read out the values for verfification.

What future work remains to be done
The approach of storing test information in a PersistentVolume is required currently as Kubernetes pod logs are not queryable in some cases one a pod succeeds.  If in the future kubernetes better supports these logs natively, we can change this to use the native logging again.  Also this should be refactored into an easier to use libray for future tests.