### PR TITLE
Implement Task/TaskRun Input Params

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -137,11 +137,12 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
-  digest = "1:1626441bf44173cc41161cbdc5cbf42309aa9488d282cfff5a00e8ea8b7eecb5"
+  digest = "1:7d4fb1e9f425e206c3f491edf55dea318080d4c7a2bd8d9bfb113f0bdd1ba90e"
   name = "github.com/knative/build"
   packages = [
     "pkg/apis/build",
     "pkg/apis/build/v1alpha1",
+    "pkg/builder",
     "pkg/client/clientset/versioned",
     "pkg/client/clientset/versioned/fake",
     "pkg/client/clientset/versioned/scheme",
@@ -154,7 +155,7 @@
     "pkg/client/listers/build/v1alpha1",
   ]
   pruneopts = "NUT"
-  revision = "7360ec685b35802d4703b31e6c0be2cc04b4503c"
+  revision = "92a1258647b272a3a4505616b102d6e8f86be082"
 
 [[projects]]
   branch = "master"
@@ -741,6 +742,7 @@
   input-imports = [
     "github.com/google/go-cmp/cmp",
     "github.com/knative/build/pkg/apis/build/v1alpha1",
+    "github.com/knative/build/pkg/builder",
     "github.com/knative/build/pkg/client/clientset/versioned",
     "github.com/knative/build/pkg/client/clientset/versioned/fake",
     "github.com/knative/build/pkg/client/clientset/versioned/typed/build/v1alpha1",
@@ -768,6 +770,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -62,7 +62,7 @@ required = [
 [[constraint]]
   name = "github.com/knative/build"
   # HEAD as of 2018-10-09
-  revision = "7360ec685b35802d4703b31e6c0be2cc04b4503c"
+  revision = "92a1258647b272a3a4505616b102d6e8f86be082"
 
 [prune]
   go-tests = true

--- a/docs/task-parameters.md
+++ b/docs/task-parameters.md
@@ -1,0 +1,49 @@
+## Task Parameters
+
+Tasks can declare input parameters that must be supplied to the task during a TaskRun.
+Some example use-cases of this include:
+
+* A task that needs to know what compilation flags to use when building an application.
+* A task that needs to know what to name a built artifact.
+* A task that supports several different strategies, and leaves the choice up to the other.
+
+### Usage
+
+The following example shows how Tasks can be parameterized, and these parameters can be passed to the `Task` from a `TaskRun`.
+
+Input parameters in the form of `${inputs.foo}` are replaced inside of the buildSpec.
+
+The following `Task` declares an input parameter called 'flags', and uses it in the `buildSpec.steps.args` list.
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-with-parameters
+spec:
+    inputs:
+        params:
+        - name: flags
+          value: string
+    buildSpec:
+        steps:
+        - name: build
+          image: my-builder
+          args: ['build', '--flags=${inputs.flags}']
+```
+
+The following `TaskRun` supplies a value for `flags`:
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: run-with-parameters
+spec:
+    taskRef:
+        name: task-with-parameters
+    inputs:
+        params:
+        - name: 'flags'
+          value: 'foo=bar,baz=bat'
+```

--- a/vendor/github.com/knative/build/pkg/builder/common.go
+++ b/vendor/github.com/knative/build/pkg/builder/common.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package builder provides common methods for Builder implementations.
+package builder
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/knative/build/pkg/apis/build/v1alpha1"
+)
+
+// ApplyTemplate applies the values in the template to the build, and replaces
+// placeholders for declared parameters with the build's matching arguments.
+func ApplyTemplate(u *v1alpha1.Build, tmpl v1alpha1.BuildTemplateInterface) (*v1alpha1.Build, error) {
+	build := u.DeepCopy()
+	if tmpl == nil {
+		return build, nil
+	}
+	tmpl = tmpl.Copy()
+	build.Spec.Steps = tmpl.TemplateSpec().Steps
+	build.Spec.Volumes = append(build.Spec.Volumes, tmpl.TemplateSpec().Volumes...)
+
+	// Apply template arguments or parameter defaults.
+	replacements := map[string]string{}
+	if tmpl != nil {
+		for _, p := range tmpl.TemplateSpec().Parameters {
+			if p.Default != nil {
+				replacements[p.Name] = *p.Default
+			}
+		}
+	}
+	if build.Spec.Template != nil {
+		for _, a := range build.Spec.Template.Arguments {
+			replacements[a.Name] = a.Value
+		}
+	}
+
+	build = ApplyReplacements(build, replacements)
+	return build, nil
+}
+
+// ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
+func ApplyReplacements(build *v1alpha1.Build, replacements map[string]string) *v1alpha1.Build {
+	build = build.DeepCopy()
+
+	applyReplacements := func(in string) string {
+		for k, v := range replacements {
+			in = strings.Replace(in, fmt.Sprintf("${%s}", k), v, -1)
+		}
+		return in
+	}
+
+	// Apply variable expansion to steps fields.
+	steps := build.Spec.Steps
+	for i := range steps {
+		steps[i].Name = applyReplacements(steps[i].Name)
+		steps[i].Image = applyReplacements(steps[i].Image)
+		for ia, a := range steps[i].Args {
+			steps[i].Args[ia] = applyReplacements(a)
+		}
+		for ie, e := range steps[i].Env {
+			steps[i].Env[ie].Value = applyReplacements(e.Value)
+		}
+		steps[i].WorkingDir = applyReplacements(steps[i].WorkingDir)
+		for ic, c := range steps[i].Command {
+			steps[i].Command[ic] = applyReplacements(c)
+		}
+		for iv, v := range steps[i].VolumeMounts {
+			steps[i].VolumeMounts[iv].Name = applyReplacements(v.Name)
+			steps[i].VolumeMounts[iv].MountPath = applyReplacements(v.MountPath)
+			steps[i].VolumeMounts[iv].SubPath = applyReplacements(v.SubPath)
+		}
+	}
+
+	if buildTmpl := build.Spec.Template; buildTmpl != nil && len(buildTmpl.Env) > 0 {
+		// Apply variable expansion to the build's overridden
+		// environment variables
+		for i, e := range buildTmpl.Env {
+			buildTmpl.Env[i].Value = applyReplacements(e.Value)
+		}
+
+		for i := range steps {
+			steps[i].Env = applyEnvOverride(steps[i].Env, buildTmpl.Env)
+		}
+	}
+	return build
+}
+
+func applyEnvOverride(src, override []corev1.EnvVar) []corev1.EnvVar {
+	result := make([]corev1.EnvVar, 0, len(src)+len(override))
+	overrides := make(map[string]bool)
+
+	for _, env := range override {
+		overrides[env.Name] = true
+	}
+
+	for _, env := range src {
+		if _, present := overrides[env.Name]; !present {
+			result = append(result, env)
+		}
+	}
+
+	return append(result, override...)
+}

--- a/vendor/github.com/knative/build/pkg/builder/interface.go
+++ b/vendor/github.com/knative/build/pkg/builder/interface.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+)
+
+// Operation defines the interface for interacting with an Operation of a particular BuildProvider.
+type Operation interface {
+	// Name provides the unique name for this operation, see OperationFromStatus.
+	Name() string
+
+	// Checkpoint augments the provided BuildStatus with sufficient state to be
+	// restored by OperationFromStatus on an appropriate BuildProvider.
+	//
+	// This takes into account necessary information about the provided Build.
+	Checkpoint(*v1alpha1.Build, *v1alpha1.BuildStatus) error
+
+	// Wait blocks until the Operation completes, returning either a status for the build or an error.
+	// TODO(mattmoor): This probably shouldn't be BuildStatus, but some sort of smaller-scope thing.
+	Wait() (*v1alpha1.BuildStatus, error)
+
+	// Terminate cleans up this particular operation and returns an error if it fails
+	Terminate() error
+}
+
+// Build defines the interface for launching a build and getting an Operation by which to track it to completion.
+type Build interface {
+	// Execute launches this particular build and returns an Operation to track it's progress.
+	Execute() (Operation, error)
+}
+
+// Interface defines the set of operations that all builders must implement.
+type Interface interface {
+	// Which builder are we?
+	Builder() v1alpha1.BuildProvider
+
+	// Validate a Build for this flavor of builder.
+	Validate(*v1alpha1.Build) error
+
+	// Construct a Build for this flavor of builder from our CRD specification.
+	BuildFromSpec(*v1alpha1.Build) (Build, error)
+
+	// Construct an Operation for this flavor of builder from a BuildStatus.
+	OperationFromStatus(*v1alpha1.BuildStatus) (Operation, error)
+}
+
+// IsDone returns true if the build's status indicates the build is done.
+func IsDone(status *v1alpha1.BuildStatus) bool {
+	if status == nil || len(status.Conditions) == 0 {
+		return false
+	}
+	for _, cond := range status.Conditions {
+		if cond.Type == v1alpha1.BuildSucceeded {
+			return cond.Status != corev1.ConditionUnknown
+		}
+	}
+	return false
+}
+
+// IsTimeout returns true if the build's execution time is greater than
+// specified build spec timeout.
+func IsTimeout(status *v1alpha1.BuildStatus, buildTimeout *metav1.Duration) bool {
+	var timeout time.Duration
+	var defaultTimeout = 10 * time.Minute
+
+	if status == nil {
+		return false
+	}
+
+	if buildTimeout == nil {
+		// Set default timeout to 10 minute if build timeout is not set
+		timeout = defaultTimeout
+	} else {
+		timeout = buildTimeout.Duration
+	}
+
+	// If build has not started timeout, startTime should be zero.
+	if status.StartTime.Time.IsZero() {
+		return false
+	}
+	return time.Since(status.StartTime.Time).Seconds() > timeout.Seconds()
+}
+
+// ErrorMessage returns the error message from the status.
+func ErrorMessage(status *v1alpha1.BuildStatus) (string, bool) {
+	if status == nil || len(status.Conditions) == 0 {
+		return "", false
+	}
+	for _, cond := range status.Conditions {
+		if cond.Type == v1alpha1.BuildSucceeded && cond.Status == corev1.ConditionFalse {
+			return cond.Message, true
+		}
+	}
+	return "", false
+}


### PR DESCRIPTION
This adds support for Task/TaskRun Input Parameters using the 'ApplyReplacements' function from knative/build.
Reusing this function ensures consistency in variable replacement between the projects.

This change assumes that the supplied TaskRun.Spec.Inputs.Params have been valided against the Task.Inputs.Params elsewhere.
We may want to revisit this and perform additional validation.

This change does not introduce support for Resources or PipelineParams yet.

Vendor changes have been separated into another commit for easier reviewing.
Ref https://github.com/knative/build-pipeline/issues/64