### PR TITLE
Implement template variable expansion for Resources.

### DIFF
--- a/docs/pipeline-resources.md
+++ b/docs/pipeline-resources.md
@@ -78,3 +78,21 @@ spec:
           - name: builtImage
             type: image
 ``` 
+
+#### Templating
+
+Git Resources (like all Resources) support template expansion into BuildSpecs.
+Git Resources support the following keys for replacement:
+
+* name
+* url
+* type
+* revision
+
+These can be referenced in a TaskRun spec like:
+
+```shell
+${inputs.resources.NAME.KEY}
+```
+
+where NAME is the Resource Name and KEY is the key from the above list.

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -81,3 +81,13 @@ func (s *GitResource) GetURL() string {
 
 // GetParams returns the resoruce params
 func (s GitResource) GetParams() []Param { return []Param{} }
+
+// Replacements is used for template replacement on a GitResource inside of a Taskrun.
+func (s *GitResource) Replacements() map[string]string {
+	return map[string]string{
+		"name":     s.Name,
+		"type":     string(s.Type),
+		"url":      s.URL,
+		"revision": s.Revision,
+	}
+}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -116,11 +116,13 @@ type PipelineResourceList struct {
 	Items           []PipelineResource `json:"items"`
 }
 
-// ResourceFromType returns a
+// ResourceFromType returns a PipelineResourceInterface from a PipelineResource's type.
 func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
 	switch r.Spec.Type {
 	case PipelineResourceTypeGit:
 		return NewGitResource(r)
+	case PipelineResourceTypeImage:
+		return NewImageResource(r)
 	}
-	return nil, fmt.Errorf("%s is an invalid PipelineResource", r.Spec.Type)
+	return nil, fmt.Errorf("%s is an invalid or unimplemented PipelineResource", r.Spec.Type)
 }

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	"github.com/knative/pkg/apis"
 	"github.com/knative/pkg/webhook"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +48,7 @@ type PipelineResourceInterface interface {
 	GetType() PipelineResourceType
 	GetParams() []Param
 	GetVersion() string
+	Replacements() map[string]string
 }
 
 // PipelineResourceSpec defines  an individual resources used in the pipeline.
@@ -111,4 +114,13 @@ type PipelineResourceList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []PipelineResource `json:"items"`
+}
+
+// ResourceFromType returns a
+func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
+	switch r.Spec.Type {
+	case PipelineResourceTypeGit:
+		return NewGitResource(r)
+	}
+	return nil, fmt.Errorf("%s is an invalid PipelineResource", r.Spec.Type)
 }

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	"github.com/knative/build/pkg/builder"
+)
+
+// ApplyParameters applies the params from a TaskRun.Input.Parameters to a BuildSpec.
+func ApplyParameters(b *buildv1alpha1.Build, tr *v1alpha1.TaskRun) *buildv1alpha1.Build {
+	// This assumes that the TaskRun inputs have been validated against what the Task requests.
+	replacements := map[string]string{}
+	for _, p := range tr.Spec.Inputs.Params {
+		replacements[fmt.Sprintf("inputs.params.%s", p.Name)] = p.Value
+	}
+
+	return builder.ApplyReplacements(b, replacements)
+}
+
+type ResourceGetter interface {
+	Get(string) (*v1alpha1.PipelineResource, error)
+}
+
+// ApplyResources applies the params from a TaskRun.Input.Resources to a BuildSpec.
+func ApplyResources(b *buildv1alpha1.Build, tr *v1alpha1.TaskRun, getter ResourceGetter) (*buildv1alpha1.Build, error) {
+	replacements := map[string]string{}
+
+	for _, ir := range tr.Spec.Inputs.Resources {
+		pr, err := getter.Get(ir.ResourceRef.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		resource, err := v1alpha1.ResourceFromType(pr)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range resource.Replacements() {
+			replacements[fmt.Sprintf("inputs.resources.%s.%s", ir.ResourceRef.Name, k)] = v
+		}
+	}
+	return builder.ApplyReplacements(b, replacements), nil
+}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var simpleBuild = &buildv1alpha1.Build{
+	Spec: buildv1alpha1.BuildSpec{
+		Steps: []corev1.Container{
+			{
+				Name:  "foo",
+				Image: "${inputs.params.myimage}",
+			},
+			{
+				Name:  "baz",
+				Image: "bat",
+				Args:  []string{"${inputs.resources.git-resource.url}"},
+			},
+		},
+	},
+}
+
+var paramTaskRun = &v1alpha1.TaskRun{
+	Spec: v1alpha1.TaskRunSpec{
+		Inputs: v1alpha1.TaskRunInputs{
+			Params: []v1alpha1.Param{
+				{
+					Name:  "myimage",
+					Value: "bar",
+				},
+			},
+		},
+	},
+}
+
+var resourceTaskRun = &v1alpha1.TaskRun{
+	Spec: v1alpha1.TaskRunSpec{
+		Inputs: v1alpha1.TaskRunInputs{
+			Resources: []v1alpha1.PipelineResourceVersion{
+				{
+					ResourceRef: v1alpha1.PipelineResourceRef{
+						Name: "git-resource",
+					},
+				},
+			},
+		},
+	},
+}
+
+var gitResource = &v1alpha1.PipelineResource{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "git-resource",
+	},
+	Spec: v1alpha1.PipelineResourceSpec{
+		Type: v1alpha1.PipelineResourceTypeGit,
+		Params: []v1alpha1.Param{
+			{
+				Name:  "URL",
+				Value: "https://git-repo",
+			},
+		},
+	},
+}
+
+func applyMutation(b *buildv1alpha1.Build, f func(b *buildv1alpha1.Build)) *buildv1alpha1.Build {
+	b = b.DeepCopy()
+	f(b)
+	return b
+}
+
+func TestApplyParameters(t *testing.T) {
+	type args struct {
+		b  *buildv1alpha1.Build
+		tr *v1alpha1.TaskRun
+	}
+	tests := []struct {
+		name string
+		args args
+		want *buildv1alpha1.Build
+	}{
+		{
+			name: "single parameter",
+			args: args{
+				b:  simpleBuild,
+				tr: paramTaskRun,
+			},
+			want: applyMutation(simpleBuild, func(b *buildv1alpha1.Build) {
+				b.Spec.Steps[0].Image = "bar"
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplyParameters(tt.args.b, tt.args.tr)
+			if d := cmp.Diff(got, tt.want); d != "" {
+				t.Errorf("ApplyParameters() got diff %s", d)
+			}
+		})
+	}
+}
+
+type rg struct {
+	resources map[string]*v1alpha1.PipelineResource
+}
+
+func (rg *rg) Get(name string) (*v1alpha1.PipelineResource, error) {
+	if pr, ok := rg.resources[name]; ok {
+		return pr, nil
+	}
+	return nil, fmt.Errorf("Resource %s does not exist.", name)
+}
+
+func (rg *rg) With(name string, pr *v1alpha1.PipelineResource) *rg {
+	rg.resources[name] = pr
+	return rg
+}
+
+func mockGetter() *rg {
+	return &rg{
+		resources: map[string]*v1alpha1.PipelineResource{},
+	}
+}
+
+func TestApplyResources(t *testing.T) {
+	type args struct {
+		b      *buildv1alpha1.Build
+		tr     *v1alpha1.TaskRun
+		getter ResourceGetter
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *buildv1alpha1.Build
+		wantErr bool
+	}{
+		{
+			name: "no replacements specified",
+			args: args{
+				b:      simpleBuild,
+				tr:     paramTaskRun,
+				getter: mockGetter(),
+			},
+			want: simpleBuild,
+		},
+		{
+			name: "resource specified",
+			args: args{
+				b:      simpleBuild,
+				tr:     resourceTaskRun,
+				getter: mockGetter().With("git-resource", gitResource),
+			},
+			want: applyMutation(simpleBuild, func(b *buildv1alpha1.Build) {
+				b.Spec.Steps[1].Args = []string{"https://git-repo"}
+			}),
+		},
+		{
+			name: "resource does not exist",
+			args: args{
+				b:      simpleBuild,
+				tr:     resourceTaskRun,
+				getter: mockGetter(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ApplyResources(tt.args.b, tt.args.tr, tt.args.getter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ApplyResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if d := cmp.Diff(got, tt.want); d != "" {
+				t.Errorf("ApplyResources() diff %s", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit builds upon #149 and makes resource keys available for expansion
inside a TaskRun.

Resources are available under the namespace 'inputs.resources', and each
resource is namespaced under it's own name.

This commit adds to the PipelineResourceInterface, requiring types to support a
Replacements method. This supplies keys to be replaced.

Ref https://github.com/knative/build-pipeline/issues/64