### PR TITLE
Fix incorrect instruction in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,7 +113,7 @@ including `knative/build` (which is wrapped by [`Task`](README.md#task)):
 
 ```shell
 ko apply -f config/
-kubectl deploy -f ./third_party/config/build/release.yaml
+kubectl apply -f ./third_party/config/build/release.yaml
 ```
 
 ### Redeploy controller


### PR DESCRIPTION
In DEVELOPMENT.md the command to deploy `knative/build` is wrong.
`kubectl deploy` should be `kubectl apply`.