### PR TITLE
Add categories to build-pipeline CRDs

### DIFF
--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: Pipeline
     plural: pipelines
+    categories:
+    - all
+    - knative
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
 status:

--- a/config/300-pipelineparams.yaml
+++ b/config/300-pipelineparams.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: PipelineParams
     plural: pipelineparamses
+    categories:
+    - all
+    - knative
+    - build-pipeline    
   scope: Namespaced
   version: v1alpha1
 status:

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: PipelineRun
     plural: pipelineruns
+    categories:
+    - all
+    - knative
+    - build-pipeline    
   scope: Namespaced
   version: v1alpha1
 status:

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: PipelineResource
     plural: pipelineresources
+    categories:
+    - all
+    - knative
+    - build-pipeline    
   scope: Namespaced
   version: v1alpha1
 status:

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: Task
     plural: tasks
+    categories:
+    - all
+    - knative
+    - build-pipeline    
   scope: Namespaced
   version: v1alpha1
 status:

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -10,6 +10,10 @@ spec:
   names:
     kind: TaskRun
     plural: taskruns
+    categories:
+    - all
+    - knative
+    - build-pipeline    
   scope: Namespaced
   version: v1alpha1
 status:


### PR DESCRIPTION
## Proposed changes
Add categories to build-pipeline CRDs so you can use kubectl get <category-name> to list the resources belonging to the category
Added the following categories: 
 * all 
  * knative 
  * build-pipeline

/cc @bobcatfish 