### PR TITLE
Added entrypoint log grabber to taskrun controller

### DIFF
--- a/Concepts.md
+++ b/Concepts.md
@@ -1,7 +1,7 @@
 # Pipeline CRDs
 Pipeline CRDs is an open source implementation to configure and run CI/CD style pipelines for your kubernetes application.
 
-Pipeline CRDs creates [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) as building blocks to declare pipelines. 
+Pipeline CRDs creates [Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) as building blocks to declare pipelines.
 
 A custom resource is an extension of Kubernetes API which can create a custom [Kubernetest Object](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#understanding-kubernetes-objects).
 Once a custom resource is installed, users can create and access its objects with kubectl, just as they do for built-in resources like pods, deployments etc.
@@ -20,7 +20,9 @@ A task will run inside a container on your cluster. A Task declares,
 1. Outputs the task will produce.
 1. Sequence of steps to execute.
 
-   Each step defines an container image. This image is of type [Builder Image](https://github.com/knative/docs/blob/master/build/builder-contract.md). A Builder Image is an image whose entrypoint is a tool that performs some action and exits with a zero status on success. These entrypoints are often command-line tools, for example, git, docker, mvn, and so on.
+   Each step defines an container image. This image is of type [Builder Image](https://github.com/knative/docs/blob/master/build/builder-contract.md).  A Builder Image is an image whose `command` performs some action and exits with a zero status on success.
+
+   NOTE: Currently to get the logs out of a Builder Image, entrypoint overrides are used.  This means that each step in `steps:` must have a container with a `command:` specified.
 
 Here is an example simple Task definition which echoes "hello world". The `hello-world` task does not define any inputs or outputs.
 
@@ -37,8 +39,9 @@ spec:
     steps:
       - name: echo
         image: busybox
-        args:
+        command:
           - echo
+        args:
           - "hello world!"
 ```
 Examples of `Task` definitions with inputs and outputs are [here](./examples)

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: knative-build-pipeline-admin
 rules:
   - apiGroups: [""]
-    resources: ["pods", "namespaces", "secrets", "events", "serviceaccounts", "configmaps"]
+    resources: ["pods", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["extensions"]
     resources: ["deployments"]

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -93,23 +93,23 @@ func TestReconcile(t *testing.T) {
 		Tasks:          ts,
 		PipelineParams: pp,
 	}
-	c, _, client := test.GetPipelineRunController(d)
+	c, _, clients := test.GetPipelineRunController(d)
 	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-success")
 	if err != nil {
 		t.Errorf("Did not expect to see error when reconciling valid Pipeline but saw %s", err)
 	}
-	if len(client.Actions()) == 0 {
+	if len(clients.Pipeline.Actions()) == 0 {
 		t.Fatalf("Expected client to have been used to create a TaskRun but it wasn't")
 	}
 
 	// Check that the PipelineRun was reconciled correctly
-	reconciledRun, err := client.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-success", metav1.GetOptions{})
+	reconciledRun, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-success", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
 	}
 
 	// Check that the expected TaskRun was created
-	actual := client.Actions()[0].(ktesting.CreateAction).GetObject()
+	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject()
 	trueB := true
 	expectedTaskRun := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/entrypoint.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/entrypoint.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// MountName is the name of the pvc being mounted (which
+	// will contain the entrypoint binary and eventually the logs)
+	MountName = "tools"
+
+	mountPoint                 = "/tools"
+	entrypointBin              = mountPoint + "/entrypoint"
+	entrypointJSONConfigEnvVar = "ENTRYPOINT_OPTIONS"
+	EntrypointImage            = "gcr.io/k8s-prow/entrypoint@sha256:7c7cd8906ce4982ffee326218e9fc75da2d4896d53cabc9833b9cc8d2d6b2b8f"
+)
+
+var toolsMount = corev1.VolumeMount{
+	Name:      MountName,
+	MountPath: mountPoint,
+}
+
+// GetCopyStep will return a Build Step (Container) that will
+// copy the entrypoint binary from the entrypoint image into the
+// volume mounted at mountPoint, so that it can be mounted by
+// subsequent steps and used to capture logs.
+func GetCopyStep() corev1.Container {
+	return corev1.Container{
+		Name:         "place-tools",
+		Image:        EntrypointImage,
+		Command:      []string{"/bin/cp"},
+		Args:         []string{"/entrypoint", entrypointBin},
+		VolumeMounts: []corev1.VolumeMount{toolsMount},
+	}
+}
+
+type entrypointArgs struct {
+	Args       []string `json:"args"`
+	ProcessLog string   `json:"process_log"`
+	MarkerFile string   `json:"marker_file"`
+}
+
+func getEnvVar(cmd, args []string) (string, error) {
+	entrypointArgs := entrypointArgs{
+		Args:       append(cmd, args...),
+		ProcessLog: "/tools/process-log.txt",
+		MarkerFile: "/tools/marker-file.txt",
+	}
+	j, err := json.Marshal(entrypointArgs)
+	if err != nil {
+		return "", fmt.Errorf("couldn't marshal arguments %q for entrypoint env var: %s", entrypointArgs, err)
+	}
+	return string(j), nil
+}
+
+// TODO: add more test cases after all, e.g. with existing env
+// var and volume mounts
+
+// AddEntrypoint will modify each of the steps/containers such that
+// the binary being run is no longer the one specified by the Command
+// and the Args, but is instead the entrypoint binary, which will
+// itself invoke the Command and Args, but also capture logs.
+// TODO: This will not work when a step uses an image that has its
+// own entrypoint, i.e. `Command` is a required field. In later iterations
+// we can update the controller to inspect the image's `Entrypoint`
+// and use that if required.
+func AddEntrypoint(steps []corev1.Container) error {
+	for i := range steps {
+		step := &steps[i]
+		e, err := getEnvVar(step.Command, step.Args)
+		if err != nil {
+			return fmt.Errorf("couldn't get env var for entrypoint: %s", err)
+		}
+		step.Command = []string{entrypointBin}
+		step.Args = []string{}
+
+		step.Env = append(step.Env, corev1.EnvVar{
+			Name:  entrypointJSONConfigEnvVar,
+			Value: e,
+		})
+		step.VolumeMounts = append(step.VolumeMounts, toolsMount)
+	}
+	return nil
+}

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -18,12 +18,13 @@ package test
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/client-go/kubernetes"
 	"os"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -119,8 +120,9 @@ func getTask(repo, namespace string, withSecretConfig bool) *v1alpha1.Task {
 	}
 
 	step := corev1.Container{
-		Name:  "kaniko",
-		Image: "gcr.io/kaniko-project/executor",
+		Name:    "kaniko",
+		Image:   "gcr.io/kaniko-project/executor",
+		Command: []string{"/kaniko/executor"},
 		Args: []string{"--dockerfile=/workspace/Dockerfile",
 			fmt.Sprintf("--destination=%s", repo),
 		},

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -125,7 +125,8 @@ func TestPipelineRun_WithServiceAccount(t *testing.T) {
 						Name:  "config-docker",
 						Image: "gcr.io/cloud-builders/docker",
 						// Private docker image for Build CRD testing
-						Args: []string{"pull", "gcr.io/build-crd-testing/secret-sauce"},
+						Command: []string{"docker"},
+						Args:    []string{"pull", "gcr.io/build-crd-testing/secret-sauce"},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "docker-socket",
 							MountPath: "/var/run/docker.sock",


### PR DESCRIPTION
What is the problem being solved?
This PR addresses issue #143.  This issue is that it when Build's complete, logs from the steps the Build ran are garbage collected by kubernetes and no longer available to the user.

Why is this the best approach?
1) No special kubernetes configuration (eg. changing garbage collector values)

What other approaches did you consider?
1) Changing kubernetes garbage collection for these containers so that they are not immediately deleted and log capture was possible

What side effects will this approach have?
1) With this approach, users will have to specify the "Command" value for the containers they which to run as the Entrypoint is not retrievable.  This means that containers/flows setup to use only the Entrypoint will no longer be supported.

What future work remains to be done?
1) It is possible to have the PVCs changed to EmptyDir volumes once a log uploader is created.  This will help with the issue that currently PVCs are being created and not cleaned up.

Co-authored-by: Christie Wilson <christiewilson@google.com>