### PR TITLE
Declare taskrun reference on pipeline object

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -120,4 +121,14 @@ type PipelineRunList struct {
 // and produces logs.
 type PipelineTaskRun struct {
 	Name string `json:"name"`
+}
+
+// GetTaskRunRef for pipelinerun
+func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
+	return corev1.ObjectReference{
+		APIVersion: "build-pipeline.knative.dev/v1alpha1",
+		Kind:       "TaskRun",
+		Namespace:  pr.Namespace,
+		Name:       pr.Name,
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -1,0 +1,64 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPipelineRunStatusConditions(t *testing.T) {
+	p := &PipelineRun{}
+	foo := &duckv1alpha1.Condition{
+		Type:   "Foo",
+		Status: "True",
+	}
+	bar := &duckv1alpha1.Condition{
+		Type:   "Bar",
+		Status: "True",
+	}
+
+	var ignoreVolatileTime = cmp.Comparer(func(_, _ apis.VolatileTime) bool {
+		return true
+	})
+
+	// Add a new condition.
+	p.Status.SetCondition(foo)
+
+	fooStatus := p.Status.GetCondition(foo.Type)
+	if d := cmp.Diff(fooStatus, foo, ignoreVolatileTime); d != "" {
+		t.Errorf("Unexpected pipeline run condition type; want %v got %v; diff %v", fooStatus, foo, d)
+	}
+
+	// Add a second condition.
+	p.Status.SetCondition(bar)
+
+	barStatus := p.Status.GetCondition(bar.Type)
+
+	if d := cmp.Diff(barStatus, bar, ignoreVolatileTime); d != "" {
+		t.Fatalf("Unexpected pipeline run condition type; want %v got %v; diff %s", barStatus, bar, d)
+	}
+}
+
+func TestPipelineRun_TaskRunref(t *testing.T) {
+	p := &PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-name",
+			Namespace: "test-ns",
+		},
+	}
+
+	expectTaskRunRef := corev1.ObjectReference{
+		APIVersion: "build-pipeline.knative.dev/v1alpha1",
+		Kind:       "TaskRun",
+		Namespace:  p.Namespace,
+		Name:       p.Name,
+	}
+
+	if d := cmp.Diff(p.GetTaskRunRef(), expectTaskRunRef); d != "" {
+		t.Fatalf("Taskrun reference mismatch; want %v got %v; diff %s", expectTaskRunRef, p.GetTaskRunRef(), d)
+	}
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/knative/pkg/tracker"
 	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,13 +129,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// Don't modify the informer's copy.
 	pr := original.DeepCopy()
 
-	taskRunRef := corev1.ObjectReference{
-		APIVersion: "build-pipeline.knative.dev/v1alpha1",
-		Kind:       "TaskRun",
-		Namespace:  pr.Namespace,
-		Name:       pr.Name,
-	}
-	if err := c.tracker.Track(taskRunRef, pr); err != nil {
+	if err := c.tracker.Track(pr.GetTaskRunRef(), pr); err != nil {
 		c.Logger.Errorf("Failed to create tracker for TaskRuns for PipelineRun %s: %v", pr.Name, err)
 		return err
 	}


### PR DESCRIPTION
- Minor refactor on pipeline run 
- Makes codes more readable
- Add tests on pipeline run status condition and taskrun ref
   - `TestPipelineRunStatusConditions` tests that `SetCondition` function on pipeline status can be used to set any ducktype condition and similarly `GetCondition` function can be used to fetch any ducktype condition. In the test I have added 2 conditions to demonstrate that we are not limiting to just setting one condition even though pipeline run uses only one condition today.