### PR TITLE
Update Run statuses correctly and stop reconciling invalid Runs

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -82,6 +82,11 @@ func (pr *PipelineRunStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1a
 	return pipelineRunCondSet.Manage(pr).GetCondition(t)
 }
 
+// InitializeConditions will set all conditions in pipelineRunCondSet to unknown for the PipelineRun
+func (ps *PipelineRunStatus) InitializeConditions() {
+	pipelineRunCondSet.Manage(ps).InitializeConditions()
+}
+
 // SetCondition sets the condition, unsetting previous conditions with the same
 // type as necessary.
 func (pr *PipelineRunStatus) SetCondition(newCond *duckv1alpha1.Condition) {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -152,17 +152,19 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) error {
 	p, err := c.pipelineLister.Pipelines(pr.Namespace).Get(pr.Spec.PipelineRef.Name)
 	if err != nil {
-		c.Logger.Errorf("%q failed to Get Pipeline: %q",
+		c.Logger.Infof("%q failed to Get Pipeline: %q",
 			fmt.Sprintf("%s/%s", pr.Namespace, pr.Name),
 			fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineRef.Name))
+		// The PipelineRun is Invalid so we want to stop trying to Reconcile it
 		return nil
 	}
 	serviceAccount, err := c.getServiceAccount(pr)
 	if err != nil {
-		c.Logger.Errorf("Pipelinerun %q failed to get pipelineparamses %q; error %v",
+		c.Logger.Infof("Pipelinerun %q failed to get pipelineparamses %q; error %v",
 			fmt.Sprintf("%s/%s", pr.Namespace, pr.Name),
 			fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineParamsRef.Name),
 			err)
+		// The PipelineRun is Invalid so we want to stop trying to Reconcile it
 		return nil
 	}
 	state, err := resources.GetPipelineState(
@@ -182,7 +184,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 			// The PipelineRun is Invalid so we want to stop trying to Reconcile it
 			return nil
 		}
-		return fmt.Errorf("error getting Tasks and/or TaskRuns for Pipeline %s, Pipeline may be invalid!: %s", p.Name, err)
+		return fmt.Errorf("error getting Tasks and/or TaskRuns for Pipeline %s: %s", p.Name, err)
 	}
 	prtr := resources.GetNextTask(pr.Name, state, c.Logger)
 	if prtr != nil {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -142,14 +142,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Don't modify the informer's copy.
 	pr := original.DeepCopy()
-	// If this is the first attempt to reconcile, mark the Run as in progress
-	if pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded) == nil {
-		pr.Status.SetCondition(&duckv1alpha1.Condition{
-			Type:   duckv1alpha1.ConditionSucceeded,
-			Status: corev1.ConditionUnknown,
-			Reason: resources.ReasonRunning,
-		})
-	}
+	pr.Status.InitializeConditions()
 
 	if err := c.tracker.Track(pr.GetTaskRunRef(), pr); err != nil {
 		c.Logger.Errorf("Failed to create tracker for TaskRuns for PipelineRun %s: %v", pr.Name, err)

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -205,9 +205,9 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
 			// and forget about the Run.
 			if err != nil {
-				t.Errorf("Did not expect to see error when reconciling but saw %s", err)
+				t.Errorf("Did not expect to see error when reconciling invalid PipelineRun but saw %q", err)
 			}
-			if tc.log != "" && logs.FilterMessage(tc.log).Len() == 0 {
+			if logs.FilterMessage(tc.log).Len() == 0 {
 				m := test.GetLogMessages(logs)
 				t.Errorf("Log lines diff %s", cmp.Diff(tc.log, m))
 			}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -86,13 +86,10 @@ func TestReconcile(t *testing.T) {
 		Tasks:          ts,
 		PipelineParams: pp,
 	}
-	c, logs, client := test.GetPipelineRunController(d)
+	c, _, client := test.GetPipelineRunController(d)
 	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-success")
 	if err != nil {
 		t.Errorf("Did not expect to see error when reconciling valid Pipeline but saw %s", err)
-	}
-	if logs.Len() > 0 {
-		t.Errorf("expected to see no error log. However found errors in logs: %v", logs)
 	}
 	if len(client.Actions()) == 0 {
 		t.Fatalf("Expected client to have been used to create a TaskRun but it wasn't")
@@ -141,49 +138,7 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func TestReconcile_InvalidPipeline(t *testing.T) {
-	prs := []*v1alpha1.PipelineRun{{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "invalid-pipeline",
-			Namespace: "foo",
-		},
-		Spec: v1alpha1.PipelineRunSpec{
-			PipelineRef: v1alpha1.PipelineRef{
-				Name: "pipeline-not-exist",
-			},
-		}},
-	}
-	d := test.Data{
-		PipelineRuns: prs,
-	}
-	tcs := []struct {
-		name        string
-		pipelineRun string
-		log         string
-	}{
-		{"invalid-pipeline-run-shd-succeed-with-logs", "foo/test-pipeline-run-doesnot-exist",
-			"pipeline run \"foo/test-pipeline-run-doesnot-exist\" in work queue no longer exists"},
-		{"invalid-pipeline-shd-succeed-with-logs", "foo/invalid-pipeline",
-			"\"foo/invalid-pipeline\" failed to Get Pipeline: \"foo/pipeline-not-exist\""},
-		{"invalid-pipeline-run-name-shd-succed-with-logs", "test/pipeline-fail/t",
-			"invalid resource key: test/pipeline-fail/t"},
-	}
-	for _, tc := range tcs {
-		t.Run(tc.name, func(t *testing.T) {
-			c, logs, _ := test.GetPipelineRunController(d)
-			err := c.Reconciler.Reconcile(context.Background(), tc.pipelineRun)
-			if err != nil {
-				t.Errorf("Did not expect to see error when reconciling but saw %s", err)
-			}
-			if tc.log != "" && logs.FilterMessage(tc.log).Len() == 0 {
-				m := test.GetLogMessages(logs)
-				t.Errorf("Log lines diff %s", cmp.Diff(tc.log, m))
-			}
-		})
-	}
-}
-
-func TestReconcile_MissingTasks(t *testing.T) {
+func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 	ps := []*v1alpha1.Pipeline{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pipeline-missing-tasks",
@@ -196,6 +151,15 @@ func TestReconcile_MissingTasks(t *testing.T) {
 		}},
 	}
 	prs := []*v1alpha1.PipelineRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "invalid-pipeline",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "pipeline-not-exist",
+			},
+		}}, {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pipelinerun-missing-tasks",
 			Namespace: "foo",
@@ -210,9 +174,43 @@ func TestReconcile_MissingTasks(t *testing.T) {
 		PipelineRuns: prs,
 		Pipelines:    ps,
 	}
-	c, _, _ := test.GetPipelineRunController(d)
-	err := c.Reconciler.Reconcile(context.Background(), "foo/pipelinerun-missing-tasks")
-	if err != nil {
-		t.Errorf("When Pipeline's Tasks can't be found, expected no error to be returned (i.e. controller should stop trying to reconcile) but got: %s", err)
+	tcs := []struct {
+		name        string
+		pipelineRun string
+		log         string
+	}{
+		{
+			name:        "invalid-pipeline-run-shd-stop-reconciling",
+			pipelineRun: "foo/test-pipeline-run-doesnot-exist",
+			log:         "pipeline run \"foo/test-pipeline-run-doesnot-exist\" in work queue no longer exists",
+		}, {
+			name:        "invalid-pipeline-shd-be-stop-reconciling",
+			pipelineRun: "foo/invalid-pipeline",
+			log:         "\"foo/invalid-pipeline\" failed to Get Pipeline: \"foo/pipeline-not-exist\"",
+		}, {
+			name:        "invalid-pipeline-run-name-shd-stop-reconciling",
+			pipelineRun: "test/pipeline-fail/t",
+			log:         "invalid resource key: test/pipeline-fail/t",
+		}, {
+			name:        "invalid-pipeline-run-missing-tasks-shd-stop-reconciling",
+			pipelineRun: "foo/pipelinerun-missing-tasks",
+			log:         "PipelineRun foo/pipeline-missing-tasks's Pipeline foo/pipelinerun-missing-tasks can't be Run; it contains Tasks that don't exist: task.pipeline.knative.dev \"sometask\" not found",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			c, logs, _ := test.GetPipelineRunController(d)
+			err := c.Reconciler.Reconcile(context.Background(), tc.pipelineRun)
+			// When a PipelineRun is invalid and can't run, we don't want to return an error because
+			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
+			// and forget about the Run.
+			if err != nil {
+				t.Errorf("Did not expect to see error when reconciling but saw %s", err)
+			}
+			if tc.log != "" && logs.FilterMessage(tc.log).Len() == 0 {
+				m := test.GetLogMessages(logs)
+				t.Errorf("Log lines diff %s", cmp.Diff(tc.log, m))
+			}
+		})
 	}
 }

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -80,7 +80,7 @@ func TestReconcile(t *testing.T) {
 			ServiceAccount: "test-sa",
 		},
 	}}
-	d := test.TestData{
+	d := test.Data{
 		PipelineRuns:   prs,
 		Pipelines:      ps,
 		Tasks:          ts,
@@ -153,7 +153,7 @@ func TestReconcile_InvalidPipeline(t *testing.T) {
 			},
 		}},
 	}
-	d := test.TestData{
+	d := test.Data{
 		PipelineRuns: prs,
 	}
 	tcs := []struct {
@@ -206,7 +206,7 @@ func TestReconcile_MissingTasks(t *testing.T) {
 			},
 		}},
 	}
-	d := test.TestData{
+	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
 	}

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
@@ -27,6 +27,19 @@ import (
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
+const (
+	// ReasonRunning indicates that the reason for the inprogress status is that the TaskRun
+	// is just starting to be reconciled
+	ReasonRunning = "Running"
+
+	// ReasonFailed indicates that the reason for the failure status is that one of the TaskRuns failed
+	ReasonFailed = "Failed"
+
+	// ReasonSucceeded indicates that the reason for the finished status is that all of the TaskRuns
+	// completed successfully
+	ReasonSucceeded = "Succeeded"
+)
+
 // GetNextTask returns the next Task for which a TaskRun should be created,
 // or nil if no TaskRun should be created.
 func GetNextTask(prName string, state []*PipelineRunTaskRun, logger *zap.SugaredLogger) *PipelineRunTaskRun {
@@ -159,7 +172,7 @@ func GetPipelineConditionStatus(prName string, state []*PipelineRunTaskRun, logg
 			return &duckv1alpha1.Condition{
 				Type:    duckv1alpha1.ConditionSucceeded,
 				Status:  corev1.ConditionFalse,
-				Reason:  "Failed",
+				Reason:  ReasonFailed,
 				Message: fmt.Sprintf("TaskRun %s for Task %s has failed", prtr.TaskRun.Name, prtr.Task.Name),
 			}
 		}
@@ -173,7 +186,7 @@ func GetPipelineConditionStatus(prName string, state []*PipelineRunTaskRun, logg
 		return &duckv1alpha1.Condition{
 			Type:    duckv1alpha1.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  "Running",
+			Reason:  ReasonRunning,
 			Message: "Not all Tasks in the Pipeline have finished executing",
 		}
 	}
@@ -181,7 +194,7 @@ func GetPipelineConditionStatus(prName string, state []*PipelineRunTaskRun, logg
 	return &duckv1alpha1.Condition{
 		Type:    duckv1alpha1.ConditionSucceeded,
 		Status:  corev1.ConditionTrue,
-		Reason:  "Finished",
+		Reason:  ReasonSucceeded,
 		Message: "All Tasks have completed executing",
 	}
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -157,8 +157,11 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		// Build is not present, create build
 		build, err = c.createBuild(tr)
 		if err != nil {
-			c.Logger.Errorf("Failed to create build for task %q :%v", tr.Name, err)
-			return err
+			c.Logger.Infof("TaskRun %s can't be Run; it references a Task %s that doesn't exist: %v",
+				fmt.Sprintf("%s/%s", tr.Namespace, tr.Name),
+				fmt.Sprintf("%s/%s", tr.Namespace, tr.Spec.TaskRef.Name), err)
+			// The PipelineRun is Invalid so we want to stop trying to Reconcile it
+			return nil
 		}
 	} else if err != nil {
 		c.Logger.Errorf("Failed to reconcile taskrun: %q, failed to get build %q; %v", tr.Name, tr.Name, err)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -157,7 +157,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		// Build is not present, create build
 		build, err = c.createBuild(tr)
 		if err != nil {
-			c.Logger.Errorf("Failed to create build for task %q :%v", err, tr.Name)
+			c.Logger.Errorf("Failed to create build for task %q :%v", tr.Name, err)
 			return err
 		}
 	} else if err != nil {
@@ -201,12 +201,12 @@ func (c *Reconciler) createBuild(tr *v1alpha1.TaskRun) (*buildv1alpha1.Build, er
 	// Get related task for taskrun
 	t, err := c.taskLister.Tasks(tr.Namespace).Get(tr.Spec.TaskRef.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Error when listing tasks %v", err)
+		return nil, fmt.Errorf("error when listing tasks %v", err)
 	}
 
 	// TODO: Preferably use Validate on task.spec to catch validation error
 	if t.Spec.BuildSpec == nil {
-		return nil, fmt.Errorf("Task %s has nil BuildSpec", t.Name)
+		return nil, fmt.Errorf("task %s has nil BuildSpec", t.Name)
 	}
 
 	b := &buildv1alpha1.Build{

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -11,33 +11,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package taskrun
+package taskrun_test
 
 import (
 	"context"
 	"testing"
-	"time"
 
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
-	fakepipelineclientset "github.com/knative/build-pipeline/pkg/client/clientset/versioned/fake"
-	informers "github.com/knative/build-pipeline/pkg/client/informers/externalversions"
-	tinformers "github.com/knative/build-pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
-	"github.com/knative/build-pipeline/pkg/reconciler"
+	"github.com/knative/build-pipeline/test"
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
-	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
-	buildinformers "github.com/knative/build/pkg/client/informers/externalversions"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"github.com/knative/pkg/controller"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
@@ -156,10 +146,10 @@ func TestReconcileBuildsCreated(t *testing.T) {
 		},
 	}
 
-	d := testData{
-		taskruns:  taskruns,
-		tasks:     []*v1alpha1.Task{simpleTask, templatedTask},
-		resources: []*v1alpha1.PipelineResource{gitResource},
+	d := test.TestData{
+		TaskRuns:          taskruns,
+		Tasks:             []*v1alpha1.Task{simpleTask, templatedTask},
+		PipelineResources: []*v1alpha1.PipelineResource{gitResource},
 	}
 	testcases := []struct {
 		name            string
@@ -212,12 +202,12 @@ func TestReconcileBuildsCreated(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, client := getController(d)
+			c, _, _, buildClient := test.GetTaskRunController(d)
 			if err := c.Reconciler.Reconcile(context.Background(), tc.taskRun); err != nil {
 				t.Errorf("expected no error. Got error %v", err)
 			}
 
-			if len(client.bclient.Actions()) == 0 {
+			if len(buildClient.Actions()) == 0 {
 				t.Errorf("Expected actions to be logged in the buildclient, got none")
 			}
 			namespace, name, err := cache.SplitMetaNamespaceKey(tc.taskRun)
@@ -225,7 +215,7 @@ func TestReconcileBuildsCreated(t *testing.T) {
 				t.Errorf("Invalid resource key: %v", err)
 			}
 			// check error
-			build, err := client.bclient.BuildV1alpha1().Builds(namespace).Get(name, metav1.GetOptions{})
+			build, err := buildClient.BuildV1alpha1().Builds(namespace).Get(name, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Failed to fetch build: %v", err)
 			}
@@ -256,9 +246,9 @@ func TestReconcileBuildCreationErrors(t *testing.T) {
 		simpleTask,
 	}
 
-	d := testData{
-		taskruns: taskRuns,
-		tasks:    tasks,
+	d := test.TestData{
+		TaskRuns: taskRuns,
+		Tasks:    tasks,
 	}
 
 	testcases := []struct {
@@ -273,14 +263,13 @@ func TestReconcileBuildCreationErrors(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, clients := getController(d)
+			c, _, _, buildClient := test.GetTaskRunController(d)
 			if err := c.Reconciler.Reconcile(context.Background(), tc.taskRun); err == nil {
 				t.Error("Expected not found error for non exitent task but got nil")
 			}
 
-			// build client will fetch build
-			if len(clients.bclient.Actions()) != 1 {
-				t.Errorf("expected no actions to be created by the reconciler, got %v", clients.bclient.Actions())
+			if len(buildClient.Actions()) != 1 {
+				t.Errorf("expected no actions to be created by the reconciler, got %v", buildClient.Actions())
 			}
 		})
 	}
@@ -300,14 +289,14 @@ func TestReconcileBuildFetchError(t *testing.T) {
 			},
 		},
 	}
-	d := testData{
-		taskruns: []*v1alpha1.TaskRun{
+	d := test.TestData{
+		TaskRuns: []*v1alpha1.TaskRun{
 			taskRun,
 		},
-		tasks: []*v1alpha1.Task{simpleTask},
+		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 
-	c, _, clients := getController(d)
+	c, _, _, buildClient := test.GetTaskRunController(d)
 
 	reactor := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetVerb() == "get" && action.GetResource().Resource == "builds" {
@@ -317,7 +306,7 @@ func TestReconcileBuildFetchError(t *testing.T) {
 		return false, nil, nil
 	}
 
-	clients.bclient.PrependReactor("*", "*", reactor)
+	buildClient.PrependReactor("*", "*", reactor)
 
 	if err := c.Reconciler.Reconcile(context.Background(), fmt.Sprintf("%s/%s", taskRun.Namespace, taskRun.Name)); err == nil {
 		t.Fatal("expected error but got nil")
@@ -337,11 +326,11 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 			},
 		},
 	}
-	d := testData{
-		taskruns: []*v1alpha1.TaskRun{
+	d := test.TestData{
+		TaskRuns: []*v1alpha1.TaskRun{
 			taskRun,
 		},
-		tasks: []*v1alpha1.Task{simpleTask},
+		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 	buildSt := &duckv1alpha1.Condition{
 		Type: duckv1alpha1.ConditionSucceeded,
@@ -350,7 +339,7 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 		Message: "Running build",
 	}
 
-	c, _, clients := getController(d)
+	c, _, pipelineClient, buildClient := test.GetTaskRunController(d)
 	build := &buildv1alpha1.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      taskRun.Name,
@@ -360,7 +349,8 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 	}
 	build.Status.SetCondition(buildSt)
 
-	_, err := clients.bclient.BuildV1alpha1().Builds(taskRun.Namespace).Create(build)
+	// TODO!
+	_, err := buildClient.BuildV1alpha1().Builds(taskRun.Namespace).Create(build)
 	if err != nil {
 		t.Errorf("error creating build : %v", err)
 	}
@@ -369,9 +359,10 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error when Reconcile() : %v", err)
 	}
 
-	newTr, err := clients.taskrunInformer.Lister().TaskRuns(taskRun.Namespace).Get(taskRun.Name)
+	newTr, err := pipelineClient.PipelineV1alpha1().TaskRuns(taskRun.Namespace).Get(taskRun.Name, metav1.GetOptions{})
+	//newTr, err := clients.taskrunInformer.Lister().TaskRuns(taskRun.Namespace).Get(taskRun.Name)
 	if err != nil {
-		t.Errorf("error: %v", err)
+		t.Fatalf("Expected TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
 	}
 	var ignoreLastTransitionTime = cmpopts.IgnoreTypes(duckv1alpha1.Condition{}.LastTransitionTime.Inner.Time)
 	if d := cmp.Diff(newTr.Status.GetCondition(duckv1alpha1.ConditionSucceeded), buildSt, ignoreLastTransitionTime); d != "" {
@@ -384,7 +375,7 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 
 	build.Status.SetCondition(buildSt)
 
-	_, err = clients.bclient.BuildV1alpha1().Builds(taskRun.Namespace).Update(build)
+	_, err = buildClient.BuildV1alpha1().Builds(taskRun.Namespace).Update(build)
 	if err != nil {
 		t.Errorf("Unexpected error while creating build: %v", err)
 	}
@@ -393,77 +384,12 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error when Reconcile(): %v", err)
 	}
 
-	newTr, err = clients.taskrunInformer.Lister().TaskRuns(taskRun.Namespace).Get(taskRun.Name)
+	newTr, err = pipelineClient.PipelineV1alpha1().TaskRuns(taskRun.Namespace).Get(taskRun.Name, metav1.GetOptions{})
+	//newTr, err = clients.taskrunInformer.Lister().TaskRuns(taskRun.Namespace).Get(taskRun.Name)
 	if err != nil {
 		t.Fatalf("Unexpected error fetching taskrun: %v", err)
 	}
 	if d := cmp.Diff(newTr.Status.GetCondition(duckv1alpha1.ConditionSucceeded), buildSt, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Taskrun Status diff -want, +got: %v", d)
 	}
-}
-
-func getController(d testData) (*controller.Impl, *observer.ObservedLogs, testClients) {
-	pipelineClient := fakepipelineclientset.NewSimpleClientset()
-	buildClient := fakebuildclientset.NewSimpleClientset()
-
-	sharedInformer := informers.NewSharedInformerFactory(pipelineClient, 0)
-
-	buildInformerFactory := buildinformers.NewSharedInformerFactory(buildClient, time.Second*30)
-	buildInformer := buildInformerFactory.Build().V1alpha1().Builds()
-
-	taskRunInformer := sharedInformer.Pipeline().V1alpha1().TaskRuns()
-	taskInformer := sharedInformer.Pipeline().V1alpha1().Tasks()
-	resourceInformer := sharedInformer.Pipeline().V1alpha1().PipelineResources()
-
-	for _, tr := range d.taskruns {
-		taskRunInformer.Informer().GetIndexer().Add(tr)
-		pipelineClient.PipelineV1alpha1().TaskRuns(tr.Namespace).Create(tr)
-	}
-	for _, t := range d.tasks {
-		taskInformer.Informer().GetIndexer().Add(t)
-		pipelineClient.PipelineV1alpha1().Tasks(t.Namespace).Create(t)
-	}
-
-	for _, r := range d.resources {
-		resourceInformer.Informer().GetIndexer().Add(r)
-	}
-
-	// Create a log observer to record all error logs.
-	observer, logs := observer.New(zap.ErrorLevel)
-	return NewController(
-			reconciler.Options{
-				Logger:            zap.New(observer).Sugar(),
-				KubeClientSet:     fakekubeclientset.NewSimpleClientset(),
-				PipelineClientSet: pipelineClient,
-				BuildClientSet:    buildClient,
-			},
-			taskRunInformer,
-			taskInformer,
-			buildInformer,
-			resourceInformer,
-		), logs, testClients{
-			pipelineClient:  pipelineClient,
-			bclient:         buildClient,
-			taskrunInformer: taskRunInformer,
-		}
-}
-
-func getLogMessages(logs *observer.ObservedLogs) []string {
-	messages := []string{}
-	for _, l := range logs.All() {
-		messages = append(messages, l.Message)
-	}
-	return messages
-}
-
-type testData struct {
-	taskruns  []*v1alpha1.TaskRun
-	tasks     []*v1alpha1.Task
-	resources []*v1alpha1.PipelineResource
-}
-
-type testClients struct {
-	bclient         *fakebuildclientset.Clientset
-	pipelineClient  *fakepipelineclientset.Clientset
-	taskrunInformer tinformers.TaskRunInformer
 }

--- a/test/controller.go
+++ b/test/controller.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	fakepipelineclientset "github.com/knative/build-pipeline/pkg/client/clientset/versioned/fake"
+	informers "github.com/knative/build-pipeline/pkg/client/informers/externalversions"
+	informersv1alpha1 "github.com/knative/build-pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/reconciler"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun"
+	fakebuildclientset "github.com/knative/build/pkg/client/clientset/versioned/fake"
+	buildinformers "github.com/knative/build/pkg/client/informers/externalversions"
+	"github.com/knative/pkg/controller"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+// GetLogMessages returns a list of all string logs in logs.
+func GetLogMessages(logs *observer.ObservedLogs) []string {
+	messages := []string{}
+	for _, l := range logs.All() {
+		messages = append(messages, l.Message)
+	}
+	return messages
+}
+
+// TestData represents the desired state of the system (i.e. existing resources) to seed controllers
+// with.
+type TestData struct {
+	PipelineRuns      []*v1alpha1.PipelineRun
+	Pipelines         []*v1alpha1.Pipeline
+	TaskRuns          []*v1alpha1.TaskRun
+	Tasks             []*v1alpha1.Task
+	PipelineParams    []*v1alpha1.PipelineParams
+	PipelineResources []*v1alpha1.PipelineResource
+}
+
+func seedTestData(d TestData) (*fakepipelineclientset.Clientset,
+	informersv1alpha1.PipelineRunInformer, informersv1alpha1.PipelineInformer,
+	informersv1alpha1.TaskRunInformer, informersv1alpha1.TaskInformer,
+	informersv1alpha1.PipelineParamsInformer, informersv1alpha1.PipelineResourceInformer) {
+	objs := []runtime.Object{}
+	for _, pr := range d.PipelineRuns {
+		objs = append(objs, pr)
+	}
+	for _, p := range d.Pipelines {
+		objs = append(objs, p)
+	}
+	for _, tr := range d.TaskRuns {
+		objs = append(objs, tr)
+	}
+	for _, t := range d.Tasks {
+		objs = append(objs, t)
+	}
+	for _, r := range d.PipelineResources {
+		objs = append(objs, r)
+	}
+	pipelineClient := fakepipelineclientset.NewSimpleClientset(objs...)
+
+	sharedInformer := informers.NewSharedInformerFactory(pipelineClient, 0)
+	pipelineRunsInformer := sharedInformer.Pipeline().V1alpha1().PipelineRuns()
+	pipelineInformer := sharedInformer.Pipeline().V1alpha1().Pipelines()
+	taskRunInformer := sharedInformer.Pipeline().V1alpha1().TaskRuns()
+	taskInformer := sharedInformer.Pipeline().V1alpha1().Tasks()
+	pipelineParamsInformer := sharedInformer.Pipeline().V1alpha1().PipelineParamses()
+	resourceInformer := sharedInformer.Pipeline().V1alpha1().PipelineResources()
+
+	for _, pr := range d.PipelineRuns {
+		pipelineRunsInformer.Informer().GetIndexer().Add(pr)
+	}
+	for _, p := range d.Pipelines {
+		pipelineInformer.Informer().GetIndexer().Add(p)
+	}
+	for _, tr := range d.TaskRuns {
+		taskRunInformer.Informer().GetIndexer().Add(tr)
+	}
+	for _, t := range d.Tasks {
+		taskInformer.Informer().GetIndexer().Add(t)
+	}
+	for _, t := range d.PipelineParams {
+		pipelineParamsInformer.Informer().GetIndexer().Add(t)
+	}
+	for _, r := range d.PipelineResources {
+		resourceInformer.Informer().GetIndexer().Add(r)
+	}
+	return pipelineClient, pipelineRunsInformer, pipelineInformer, taskRunInformer, taskInformer, pipelineParamsInformer, resourceInformer
+}
+
+// GetTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
+// d, where d represents the state of the system (existing resources) needed for the test.
+func GetTaskRunController(d TestData) (*controller.Impl, *observer.ObservedLogs, *fakepipelineclientset.Clientset, *fakebuildclientset.Clientset) {
+	pipelineClient, _, _, taskRunInformer, taskInformer, _, resourceInformer := seedTestData(d)
+
+	buildClient := fakebuildclientset.NewSimpleClientset()
+	buildInformerFactory := buildinformers.NewSharedInformerFactory(buildClient, 0)
+	buildInformer := buildInformerFactory.Build().V1alpha1().Builds()
+
+	// Create a log observer to record all error logs.
+	observer, logs := observer.New(zap.ErrorLevel)
+	return taskrun.NewController(
+		reconciler.Options{
+			Logger:            zap.New(observer).Sugar(),
+			KubeClientSet:     fakekubeclientset.NewSimpleClientset(),
+			PipelineClientSet: pipelineClient,
+			BuildClientSet:    buildClient,
+		},
+		taskRunInformer,
+		taskInformer,
+		buildInformer,
+		resourceInformer,
+	), logs, pipelineClient, buildClient
+}
+
+// GetPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
+// d, where d represents the state of the system (existing resources) needed for the test.
+func GetPipelineRunController(d TestData) (*controller.Impl, *observer.ObservedLogs, *fakepipelineclientset.Clientset) {
+	pipelineClient, pipelineRunsInformer, pipelineInformer, taskRunInformer, taskInformer, pipelineParamsInformer, _ := seedTestData(d)
+	// Create a log observer to record all error logs.
+	observer, logs := observer.New(zap.ErrorLevel)
+	return pipelinerun.NewController(
+		reconciler.Options{
+			Logger:            zap.New(observer).Sugar(),
+			KubeClientSet:     fakekubeclientset.NewSimpleClientset(),
+			PipelineClientSet: pipelineClient,
+		},
+		pipelineRunsInformer,
+		pipelineInformer,
+		taskInformer,
+		taskRunInformer,
+		pipelineParamsInformer,
+	), logs, pipelineClient
+}

--- a/test/controller.go
+++ b/test/controller.go
@@ -137,8 +137,7 @@ func seedTestData(d Data) (Clients, Informers) {
 // d, where d represents the state of the system (existing resources) needed for the test.
 func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Clients) {
 	c, i := seedTestData(d)
-	// Create a log observer to record all error logs.
-	observer, logs := observer.New(zap.ErrorLevel)
+	observer, logs := observer.New(zap.InfoLevel)
 	return taskrun.NewController(
 		reconciler.Options{
 			Logger:            zap.New(observer).Sugar(),
@@ -157,7 +156,6 @@ func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Cli
 // d, where d represents the state of the system (existing resources) needed for the test.
 func GetPipelineRunController(d Data) (*controller.Impl, *observer.ObservedLogs, *fakepipelineclientset.Clientset) {
 	c, i := seedTestData(d)
-	// Create a log observer to record all error logs.
 	observer, logs := observer.New(zap.InfoLevel)
 	return pipelinerun.NewController(
 		reconciler.Options{

--- a/test/controller.go
+++ b/test/controller.go
@@ -158,7 +158,7 @@ func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Cli
 func GetPipelineRunController(d Data) (*controller.Impl, *observer.ObservedLogs, *fakepipelineclientset.Clientset) {
 	c, i := seedTestData(d)
 	// Create a log observer to record all error logs.
-	observer, logs := observer.New(zap.ErrorLevel)
+	observer, logs := observer.New(zap.InfoLevel)
 	return pipelinerun.NewController(
 		reconciler.Options{
 			Logger:            zap.New(observer).Sugar(),


### PR DESCRIPTION
If a Run fails to start, the status should indicate it has failed.
If it is currently running, the status should indicate it is in-progress.

Otherwise, we can assume the related Builds were created and we mirror
their statuses.


Changed the log level for invalid Runs to Info b/c this means the
_user_ made an error, the Error log level should be used for when there
is an Error in the system/controller itself.

Includes some refactoring of the controller test libs. In the long run, I think we should be moving functionality out of the reconcilers themselves so that we can test it more easily without having to use fake informers/clients, and without having to assert on logs.

Fixes #174 