### PR TITLE
Remove Default Linear Pipeline Task Execution.

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -286,7 +286,7 @@ func (c *Reconciler) reconcilePipelineRunStatus(pr *v1alpha1.PipelineRun, state 
 
 func (c *Reconciler) isPipelineRunComplete(pr *v1alpha1.PipelineRun) bool {
 	// Check if Pipeline Run is already marked as completed or failed
-	if s := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded); s != nil && s.Status != corev1.ConditionUnknown {
+	if s := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded); !s.IsUnknown() {
 		// Pipeline run is either Successul or Failed.
 		c.Logger.Infof("PipelineRun is either successfully complete or marked as failed.", pr.Name)
 		return true

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/passedconstraint_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/passedconstraint_test.go
@@ -78,7 +78,7 @@ var mypipelinetasks = []v1alpha1.PipelineTask{{
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "myresource1",
 		},
-		PassedConstraints: []string{"mytask1"},
+		PassedConstraints: []string{"mypipelinetask1"},
 	}},
 }}
 

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate_test.go
@@ -276,6 +276,11 @@ func TestGetPipelineState(t *testing.T) {
 		PipelineTask: &pts[1],
 		TaskRunName:  "pipelinerun-mytask2",
 		TaskRun:      nil,
+	}, {
+		Task:         task,
+		PipelineTask: &pts[2],
+		TaskRunName:  "pipelinerun-mytask3",
+		TaskRun:      nil,
 	}}
 	if d := cmp.Diff(pipelineState, expectedState); d != "" {
 		t.Fatalf("Expected to get current pipeline state %v, but actual differed: %s", expectedState, d)

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -278,7 +278,7 @@ func getHelmDeployPipeline(namespace string) *v1alpha1.Pipeline {
 						ResourceRef: v1alpha1.PipelineResourceRef{
 							Name: sourceResourceName,
 						},
-						PassedConstraints: []string{createImageTaskName},
+						PassedConstraints: []string{"push-image"},
 					}},
 					Params: []v1alpha1.Param{{
 						Name:  "pathToHelmCharts",


### PR DESCRIPTION
Fixes #168 
Previously, `pipelinerun.Reconciler` would executed tasks in a pipeline linearly.
The `pipelinerun.resources.GetNextTask` would linearly go through all tasks `Pipeline.Spec.Tasks` and
create a `TaskRun` only if the previous task in order is complete.
In this change, for each run (once per 30 seconds),  `pipeline.Reconciler` will create `TaskRun` for the
first task in the `Pipeline.Spec.Tasks` whose inputs are ready.
Inputs for a given task in the `Pipeline.Spec.Tasks` are ready when
 - they do not depend on any other task and they `passedConstraints` specified on the input source is empty.
 - the task or tasks specified in `passedConstraints` for the input source have completed successfully.

Along with that, this chnges refactors the `pipelinerun.Reconciler.reconcile` method.
It first reconciles the pipeline run status which can be used to quickly determine if the pipeline has
already completed or failed. There by we save some processing time.