### PR TITLE
Update Dockerfile to work from inside a subfolder in the repo

### DIFF
--- a/test/gohelloworld/Dockerfile
+++ b/test/gohelloworld/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang
 
 # Copy the local package files to the container's workspace.
-ADD . /go/src/github.com/knative/build-pipeline/test/gohelloworld
+COPY . /go/src/github.com/knative/build-pipeline/
 
 RUN go install github.com/knative/build-pipeline/test/gohelloworld
 


### PR DESCRIPTION
This is just to fix the Dockerfile so the `helm task test` can use the same repo instead of an
external repo, it needs to come in a separate PR so the test can pull the repo as a github source and find the correct file

