### PR TITLE
Print all CRD as YAML on test failure

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,7 +70,7 @@
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
-  digest = "1:2e3c336fc7fde5c984d2841455a658a6d626450b1754a854b3b32e7a8f49a07a"
+  digest = "1:d2754cafcab0d22c13541618a8029a70a8959eb3525ff201fe971637e2274cd0"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
@@ -758,7 +758,9 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/ghodss/yaml",
     "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/go-containerregistry/pkg/authn",
     "github.com/google/go-containerregistry/pkg/name",
     "github.com/google/go-containerregistry/pkg/v1/remote",
@@ -769,7 +771,6 @@
     "github.com/knative/build/pkg/client/clientset/versioned/typed/build/v1alpha1",
     "github.com/knative/build/pkg/client/informers/externalversions",
     "github.com/knative/build/pkg/client/informers/externalversions/build/v1alpha1",
-    "github.com/knative/build/pkg/client/listers/build/v1alpha1",
     "github.com/knative/caching/pkg/apis/caching",
     "github.com/knative/caching/pkg/client/clientset/versioned",
     "github.com/knative/pkg/apis",
@@ -789,6 +790,7 @@
     "go.uber.org/zap",
     "go.uber.org/zap/zaptest/observer",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -57,8 +57,8 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	c, namespace := setup(t, logger)
 	setupClusterBindingForHelm(c, t, namespace, logger)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	logger.Infof("Creating Git PipelineResource %s", sourceResourceName)
 	if _, err := c.PipelineResourceClient.Create(getGoHelloworldGitResource(namespace)); err != nil {

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -196,8 +196,8 @@ func TestKanikoTaskRun(t *testing.T) {
 		t.Errorf("Expected to get docker repo")
 	}
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	hasSecretConfig, err := createSecret(c.KubeClient, namespace)
 	if err != nil {

--- a/test/pipeline_test.go
+++ b/test/pipeline_test.go
@@ -32,8 +32,8 @@ func TestPipeline(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	p, err := c.PipelineClient.List(metav1.ListOptions{})
 	if err != nil {

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -38,8 +38,8 @@ func TestPipelineRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	logger.Infof("Creating Pipeline Resources in namespace %s", namespace)
 	if _, err := c.TaskClient.Create(getHelloWorldTask(namespace, []string{"echo", taskOutput})); err != nil {
@@ -102,8 +102,8 @@ func TestPipelineRun_WithServiceAccount(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	logger.Infof("Creating pipeline resources in namespace %s", namespace)
 

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -34,8 +34,8 @@ func TestTaskRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(logger, c.KubeClient, namespace) }, logger)
-	defer tearDown(logger, c.KubeClient, namespace)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
 
 	logger.Infof("Creating Task and TaskRun in namespace %s", namespace)
 	if _, err := c.TaskClient.Create(getHelloWorldTask(namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})); err != nil {


### PR DESCRIPTION
This code will dump out all build-pipeline CRDs when a test fails to
make debugging easier.

Currently purposely makes the PipelineRun test fail.

Fixes #145.