### PR TITLE
Add image caching to build deployment

### DIFF
--- a/third_party/config/build/release.yaml
+++ b/third_party/config/build/release.yaml
@@ -112,6 +112,25 @@ subjects:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: images.caching.internal.knative.dev
+spec:
+  group: caching.internal.knative.dev
+  version: v1alpha1
+  names:
+    kind: Image
+    plural: images
+    singular: image
+    categories:
+    - all
+    - knative-internal
+    - caching
+    shortNames:
+    - img
+  scope: Namespaced
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
   name: builds.build.knative.dev
 spec:
   additionalPrinterColumns:


### PR DESCRIPTION
The image cache type is required in order for the Build controller.
While trying to build skaffold's example microservice images, I ran into
errors because the Build controller was trying to use the image cache
type and it wasn't deployed.

(This is the first of several random fixes that came up when trying to work on #89 for @dlorenc 's upcoming demo.)