### PR TITLE
Add Pipeline DAG basic implementation

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -18,44 +18,35 @@ package errors
 
 import (
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/knative/build-pipeline/pkg/system"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-var (
-	pipelineQualifiedKind = schema.GroupKind{
-		Group: v1alpha1.SchemeGroupVersion.Group,
-		Kind:  system.PipelineKind,
-	}
-)
-
 // NewDuplicatePipelineTask creates a new invalid pipeline error for duplicate pipeline tasks.
-func NewDuplicatePipelineTask(pipeline string, value string) *apierrors.StatusError {
+func NewDuplicatePipelineTask(p *v1alpha1.Pipeline, value string) *apierrors.StatusError {
 	errs := field.ErrorList{{
 		Type:     field.ErrorTypeDuplicate,
 		Field:    "spec.tasks.name",
 		BadValue: value,
 	}}
-	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+	return apierrors.NewInvalid(p.GroupVersionKind().GroupKind(), p.Name, errs)
 }
 
 // NewPipelineTaskNotFound creates a new invalid pipeline error.
-func NewPipelineTaskNotFound(pipeline string, value string) *apierrors.StatusError {
+func NewPipelineTaskNotFound(p *v1alpha1.Pipeline, value string) *apierrors.StatusError {
 	errs := field.ErrorList{{
-		Type:     field.ErrorTypeDuplicate,
-		Field:    "spec.tasks.inputSourceBindings.%s",
+		Type:     field.ErrorTypeNotFound,
+		Field:    "spec.tasks.name",
 		BadValue: value,
 	}}
-	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+	return apierrors.NewInvalid(p.GroupVersionKind().GroupKind(), p.Name, errs)
 }
 
 // NewInvalidPipeline creates a new invalid pipeline error.
-func NewInvalidPipeline(pipeline string, d string) *apierrors.StatusError {
+func NewInvalidPipeline(p *v1alpha1.Pipeline, d string) *apierrors.StatusError {
 	errs := field.ErrorList{{
 		Type:   field.ErrorTypeInternal,
 		Detail: d,
 	}}
-	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+	return apierrors.NewInvalid(p.GroupVersionKind().GroupKind(), p.Name, errs)
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/system"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+var (
+	pipelineQualifiedKind = schema.GroupKind{
+		Group: v1alpha1.SchemeGroupVersion.Group,
+		Kind:  system.PipelineKind,
+	}
+)
+
+// NewDuplicatePipelineTask creates a new invalid pipeline error for duplicate pipeline tasks.
+func NewDuplicatePipelineTask(pipeline string, value string) *apierrors.StatusError {
+	errs := field.ErrorList{{
+		Type:     field.ErrorTypeDuplicate,
+		Field:    "spec.tasks.name",
+		BadValue: value,
+	}}
+	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+}
+
+// NewPipelineTaskNotFound creates a new invalid pipeline error.
+func NewPipelineTaskNotFound(pipeline string, value string) *apierrors.StatusError {
+	errs := field.ErrorList{{
+		Type:     field.ErrorTypeDuplicate,
+		Field:    "spec.tasks.inputSourceBindings.%s",
+		BadValue: value,
+	}}
+	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+}
+
+// NewInvalidPipeline creates a new invalid pipeline error.
+func NewInvalidPipeline(pipeline string, d string) *apierrors.StatusError {
+	errs := field.ErrorList{{
+		Type:   field.ErrorTypeInternal,
+		Detail: d,
+	}}
+	return apierrors.NewInvalid(pipelineQualifiedKind, pipeline, errs)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var testPipeline = v1alpha1.Pipeline{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "foo",
+		APIVersion: "pipeline.knative.test/v1test1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pipeline",
+	},
+}
+
+func TestNewDuplicatePipelineTask(t *testing.T) {
+	err := NewDuplicatePipelineTask(&testPipeline, "duplicate")
+	expectedDetails := &metav1.StatusDetails{
+		Name:  "test-pipeline",
+		Group: "pipeline.knative.test",
+		Kind:  "foo",
+		Causes: []metav1.StatusCause{
+			{Type: metav1.CauseTypeFieldValueDuplicate,
+				Message: `Duplicate value: "duplicate"`,
+				Field:   "spec.tasks.name",
+			},
+		},
+	}
+	if d := cmp.Diff(expectedDetails, err.Status().Details); d != "" {
+		t.Errorf("expected %s, got diff %s", expectedDetails, d)
+	}
+}
+
+func TestNewPipelineTaskNotFound(t *testing.T) {
+	err := NewPipelineTaskNotFound(&testPipeline, "not-found")
+	expectedDetails := &metav1.StatusDetails{
+		Name:  "test-pipeline",
+		Group: "pipeline.knative.test",
+		Kind:  "foo",
+		Causes: []metav1.StatusCause{
+			{Type: metav1.CauseTypeFieldValueNotFound,
+				Message: `Not found: "not-found"`,
+				Field:   "spec.tasks.name",
+			},
+		},
+	}
+	if d := cmp.Diff(expectedDetails, err.Status().Details); d != "" {
+		t.Errorf("expected %s, got diff %s", expectedDetails, d)
+	}
+}
+
+func TestNewInvalidPipeline(t *testing.T) {
+	err := NewInvalidPipeline(&testPipeline, "cycle found")
+	expectedDetails := &metav1.StatusDetails{
+		Name:  "test-pipeline",
+		Group: "pipeline.knative.test",
+		Kind:  "foo",
+		Causes: []metav1.StatusCause{
+			{Type: metav1.CauseType("InternalError"),
+				Message: "Internal error: cycle found",
+			},
+		},
+	}
+	if d := cmp.Diff(err.Status().Details, expectedDetails); d != "" {
+		t.Errorf("expected %s, got diff %s", "", d)
+	}
+}

--- a/pkg/reconciler/v1alpha1/pipeline/resources/dag.go
+++ b/pkg/reconciler/v1alpha1/pipeline/resources/dag.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	errors "github.com/knative/build-pipeline/pkg/errors"
+)
+
+// DAG represents the Pipeline DAG
+type DAG struct {
+	//Nodes represent map of PipelineTask name to Node in Pipeline DAG
+	Nodes map[string]*Node
+}
+
+// Returns an empty Pipeline DAG
+func new() *DAG {
+	return &DAG{Nodes: map[string]*Node{}}
+}
+
+func (g *DAG) addPipelineTask(t v1alpha1.PipelineTask) (*Node, error) {
+	if _, ok := g.Nodes[t.Name]; ok {
+		return nil, fmt.Errorf("duplicate pipeline taks")
+	}
+	newNode := &Node{
+		Task: t,
+	}
+	g.Nodes[t.Name] = newNode
+	return newNode, nil
+}
+
+func (g *DAG) addPrevPipelineTask(prev *Node, next *Node) error {
+	// Check for self cycle
+	if prev.Task.Name == next.Task.Name {
+		return fmt.Errorf("cycle detected: task %q depends on itself", next.Task.Name)
+	}
+	// Check if we are adding cycles.
+	visited := map[string]bool{prev.Task.Name: true, next.Task.Name: true}
+	path := []string{prev.Task.Name, next.Task.Name}
+	if err := visit(prev.Prev, path, visited); err != nil {
+		return fmt.Errorf("cycle detected. %s ", getVisitedPath(path))
+	}
+	next.Prev = append(next.Prev, prev)
+	return nil
+}
+
+func visit(nodes []*Node, path []string, visited map[string]bool) error {
+	for _, n := range nodes {
+		path = append(path, n.Task.Name)
+		if _, ok := visited[n.Task.Name]; ok {
+			return fmt.Errorf(getVisitedPath(path))
+		}
+		visited[n.Task.Name] = true
+		if err := visit(n.Prev, path, visited); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getVisitedPath(path []string) string {
+	// Reverse the path since we traversed the graph using prev pointers.
+	for i := len(path)/2 - 1; i >= 0; i-- {
+		opp := len(path) - 1 - i
+		path[i], path[opp] = path[opp], path[i]
+	}
+	return strings.Join(path, "->")
+}
+
+//GetPreviousTasks return all the previous tasks for a PipelineTask in the DAG
+func (g *DAG) GetPreviousTasks(pt string) []v1alpha1.PipelineTask {
+	v, ok := g.Nodes[pt]
+	if !ok {
+		return nil
+	}
+	return v.getPrevTasks()
+}
+
+// Build returns a valid pipeline DAG. Returns error if the pipeline is invalid
+func Build(p *v1alpha1.Pipeline) (*DAG, error) {
+	d := new()
+
+	// Add all Tasks mentioned in the `PipelineSpec`
+	for _, pt := range p.Spec.Tasks {
+		if _, err := d.addPipelineTask(pt); err != nil {
+			return nil, errors.NewDuplicatePipelineTask(p.Name, pt.Name)
+		}
+	}
+	// Process all passedConstraints to add task dependency
+	for _, pt := range p.Spec.Tasks {
+		for _, input := range pt.InputSourceBindings {
+			for _, constraint := range input.PassedConstraints {
+				// We need to add dependency from constraint to node n
+				prev, ok := d.Nodes[constraint]
+				if !ok {
+					return nil, errors.NewPipelineTaskNotFound(p.Name, constraint)
+				}
+				next, _ := d.Nodes[pt.Name]
+				if err := d.addPrevPipelineTask(prev, next); err != nil {
+					return nil, errors.NewInvalidPipeline(p.Name, err.Error())
+				}
+			}
+		}
+	}
+	return d, nil
+}

--- a/pkg/reconciler/v1alpha1/pipeline/resources/dag_test.go
+++ b/pkg/reconciler/v1alpha1/pipeline/resources/dag_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuild(t *testing.T) {
+	a := v1alpha1.PipelineTask{Name: "a"}
+	b := v1alpha1.PipelineTask{Name: "b"}
+	c := v1alpha1.PipelineTask{Name: "c"}
+	xDependsOnA := v1alpha1.PipelineTask{
+		Name:                "x",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+	}
+	yDependsOnAB := v1alpha1.PipelineTask{
+		Name:                "y",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"b", "a"}}},
+	}
+	zDependsOnX := v1alpha1.PipelineTask{
+		Name:                "z",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"x"}}},
+	}
+	aDependsOnZ := v1alpha1.PipelineTask{
+		Name:                "a",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"z"}}},
+	}
+	selfLink := v1alpha1.PipelineTask{
+		Name:                "a",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+	}
+	invalidTask := v1alpha1.PipelineTask{
+		Name:                "a",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"none"}}},
+	}
+	nodeX := &Node{Task: xDependsOnA, Prev: []*Node{&Node{Task: a}}}
+
+	tcs := []struct {
+		name        string
+		spec        v1alpha1.PipelineSpec
+		expectedDAG *DAG
+		shdErr      bool
+	}{
+		{"linear-pipeline",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{a, b, c}},
+			&DAG{
+				Nodes: map[string]*Node{
+					"a": &Node{Task: a},
+					"b": &Node{Task: b},
+					"c": &Node{Task: c},
+				},
+			},
+			false},
+		{"complex-pipeline",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{a, xDependsOnA, yDependsOnAB, zDependsOnX, b, c}},
+			&DAG{
+				Nodes: map[string]*Node{
+					"a": &Node{Task: a},
+					"b": &Node{Task: b},
+					"c": &Node{Task: c},
+					"x": &Node{Task: xDependsOnA, Prev: []*Node{&Node{Task: a}}},
+					"y": &Node{Task: yDependsOnAB, Prev: []*Node{&Node{Task: b}, &Node{Task: a}}},
+					"z": &Node{Task: zDependsOnX, Prev: []*Node{nodeX}},
+				},
+			},
+			false},
+		{"self-link",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{selfLink}},
+			nil,
+			true},
+		{"cycle-2",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{xDependsOnA, zDependsOnX, aDependsOnZ}},
+			nil,
+			true},
+		{"duplicate-tasks",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{a, a}},
+			nil,
+			true},
+		{"invalid-task-name",
+			v1alpha1.PipelineSpec{Tasks: []v1alpha1.PipelineTask{invalidTask}},
+			nil,
+			true},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &v1alpha1.Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace",
+					Name:      tc.name,
+				},
+				Spec: tc.spec,
+			}
+			g, err := Build(p)
+			if hasErr(err) != tc.shdErr {
+				t.Errorf("expected to see an err %t found %s", tc.shdErr, err)
+			}
+			if d := cmp.Diff(tc.expectedDAG, g); d != "" {
+				t.Errorf("expected to see no diff in DAG but saw diff %s", cmp.Diff(tc.expectedDAG, g))
+			}
+		})
+	}
+}
+
+func TestGetPrevTasks(t *testing.T) {
+	a := v1alpha1.PipelineTask{Name: "a"}
+	x := v1alpha1.PipelineTask{
+		Name:                "x",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+	}
+	y := v1alpha1.PipelineTask{
+		Name:                "y",
+		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"x", "a"}}},
+	}
+	p := v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "namespace",
+			Name:      "test",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Tasks: []v1alpha1.PipelineTask{a, x, y},
+		},
+	}
+	g, err := Build(&p)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if d := cmp.Diff(g.GetPreviousTasks("a"), []v1alpha1.PipelineTask{}); d != "" {
+		t.Errorf("incorrect prev tasks for PipelineTask a. diff %s", d)
+	}
+	if d := cmp.Diff(g.GetPreviousTasks("x"), []v1alpha1.PipelineTask{a}); d != "" {
+		t.Errorf("incorrect prev tasks for PipelineTask x. diff %s", d)
+	}
+	if d := cmp.Diff(g.GetPreviousTasks("y"), []v1alpha1.PipelineTask{x, a}); d != "" {
+		t.Errorf("incorrect prev tasks for PipelineTask y. diff %s", d)
+	}
+}
+
+// hasErr returns true if err is not nil
+func hasErr(err error) bool {
+	return err != nil
+}

--- a/pkg/reconciler/v1alpha1/pipeline/resources/node.go
+++ b/pkg/reconciler/v1alpha1/pipeline/resources/node.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// Node represents a Task in a pipeline.
+type Node struct {
+	// Task represent the PipelineTask in Pipeline
+	Task v1alpha1.PipelineTask
+	// Prev represent all the Previous task Nodes for the current Task
+	Prev []*Node
+}
+
+func (n Node) getPrevTasks() []v1alpha1.PipelineTask {
+	p := make([]v1alpha1.PipelineTask, len(n.Prev))
+	for i := range n.Prev {
+		p[i] = n.Prev[i].Task
+	}
+	return p
+}
+
+func (n Node) printPrevTasks() string {
+	s := make([]string, len(n.Prev))
+	for i, n := range n.Prev {
+		s[i] = n.Task.Name
+	}
+	return fmt.Sprintf("Previous tasks: [%s]", strings.Join(s, ","))
+}
+
+func (n Node) String() string {
+	return fmt.Sprintf("PipelineTask.Name: %s, %s", n.Task.Name, n.printPrevTasks())
+}

--- a/pkg/system/names.go
+++ b/pkg/system/names.go
@@ -19,5 +19,6 @@ package system
 const (
 	// Namespace holds the K8s namespace where our build-pipeline system
 	// components run.
-	Namespace = "knative-build-pipeline"
+	Namespace    = "knative-build-pipeline"
+	PipelineKind = "Pipeline"
 )


### PR DESCRIPTION
`reconciler.pipeline.resources.Build` creates DAG for a given Pipeline.

This DAG is represented as a List of Nodes.
Each DAG `Node` has reference to the PipelineTask in the PipelineSpec and
list of task it depends on in `Node.Prev`
For now, the DAG is one-directional only i.e. from current PipelineTask you can
get to previous `PipelineTasks` and not the other way around.
This basic implementation of DAG with no traversing.

The `Build` function raises an error if the PipelineSpec is invalid.
It validates the graph and raises error when
1. A pipeline defines multiple PipelineTask with same name in the PipelineSpec.Tasks
2. A pipeline adds a dependency on PipelineTask which does not exists.
3. A pipeline has a cycyle.
The first two validations are also handled in the Pipeline Validation during creation.
However, it does not harm to add it in here.