### PR TITLE
Check of passed constraint should use pipeline task name

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -37,6 +37,7 @@ need.
 * The `passedConstraints` allows for `Tasks` to fan in and fan out, and ordering can be
   expressed explicitly using this key since a task needing a resource from a another
   task would have to run after.
+* The name used in the `passedConstraints` is the name of `PipelineTask`  
 
 ## Creating a Task
 

--- a/examples/pipelines/guestbook.yaml
+++ b/examples/pipelines/guestbook.yaml
@@ -53,7 +53,7 @@ spec:
               resourceRef:
                   name: guestbook-resources-redis-docker  
               passedConstraints:
-               - build-push
+               - build-redis
           params:
               - name: pathToFiles
                 value: guestbook/all-in-one/guestbook-all-in-one.yaml

--- a/examples/pipelines/kritis.yaml
+++ b/examples/pipelines/kritis.yaml
@@ -24,8 +24,7 @@ spec:
             key: workspace # bind to the name in the task
             resourceRef:
               name: kritis-resources-git
-            passedConstraints:
-              - unit-test-make
+            passedConstraints: [unit-test-kritis]
         outputSourceBindings:
           - name: kritisImage
             key: builtImage # bind to the name in the task
@@ -42,7 +41,7 @@ spec:
             key: workspace
             resourceRef:
               name: kritis-resources-image
-            passedConstraints: [build-push]
+            passedConstraints: [push-kritis]
         params:
           - name: pathToHelmCharts
             value: kritis-charts
@@ -57,7 +56,7 @@ spec:
             key: workspace
             resourceRef:
                 name: kritis-resources-test-git
-            passedConstraints: [deploy-with-helm]
+            passedConstraints: [deploy-test-env]
         params:
           - name: testArgs
             value: "-e REMOTE_INTEGRATION=true"

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/passedconstraint_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/passedconstraint_test.go
@@ -78,7 +78,7 @@ var mypipelinetasks = []v1alpha1.PipelineTask{{
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "myresource1",
 		},
-		PassedConstraints: []string{"mytask1"},
+		PassedConstraints: []string{"mypipelinetask1"},
 	}},
 }}
 

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
@@ -74,7 +74,7 @@ func canTaskRun(pt *v1alpha1.PipelineTask, state []*PipelineRunTaskRun) bool {
 			for _, constrainingTaskName := range input.PassedConstraints {
 				for _, prtr := range state {
 					// the constraining task must have a successful task run to allow this task to run
-					if prtr.Task.Name == constrainingTaskName {
+					if prtr.PipelineTask.Name == constrainingTaskName {
 						if prtr.TaskRun == nil {
 							return false
 						}


### PR DESCRIPTION

Check of passed constraint should use pipeline task name instead of task name to check the dependency in the pipeline
This makes writing the pipeline yaml easier 
in addition also:
 * updates examples 
 * updates tests 

could be part of #138 

/cc @tejal29 @shashwathi 