### PR TITLE
Docs: fix typo

### DIFF
--- a/docs/Concepts.md
+++ b/docs/Concepts.md
@@ -171,7 +171,7 @@ requirements of the `Task`.
 Creating a `PipelineRun` executes the pipeline, creating [TaskRuns](#taskrun) for each 
 task in the pipeline.
 
-`PipelineRuns` tie together a [Pipeline](#pipeline) and a [PipelineParam](#pipelineparam.
+`PipelineRuns` tie together a [Pipeline](#pipeline) and a [PipelineParam](#pipelineparams).
 
 A `PipelineRun` could be created:
 


### PR DESCRIPTION
Fix the noneffective link of `PipelineParma`.