### PR TITLE
Add labels for tracking objects lineage

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -17,4 +17,10 @@ limitations under the License.
 package pipeline
 
 // GroupName is the Kubernetes resource group name for Pipeline types.
-const GroupName = "pipeline.knative.dev"
+const (
+	GroupName           = "pipeline.knative.dev"
+	TaskRunLabelKey     = "/taskRun"
+	PipelineLabelKey    = "/pipeline"
+	PipelineRunLabelKey = "/pipelineRun"
+)
+

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/knative/build-pipeline/pkg/apis/pipeline"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/knative/build-pipeline/pkg/reconciler"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
@@ -224,6 +225,10 @@ func (c *Reconciler) createTaskRun(t *v1alpha1.Task, trName string, pr *v1alpha1
 			Namespace: t.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(pr, groupVersionKind),
+			},
+			Labels: map[string]string{
+				pipeline.GroupName + pipeline.PipelineLabelKey:    pr.Spec.PipelineRef.Name,
+				pipeline.GroupName + pipeline.PipelineRunLabelKey: pr.Name,
 			},
 		},
 		Spec: v1alpha1.TaskRunSpec{

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -174,6 +174,10 @@ func TestReconcile(t *testing.T) {
 				Controller:         &trueB,
 				BlockOwnerDeletion: &trueB,
 			}},
+			Labels: map[string]string{
+				"pipeline.knative.dev/pipeline": "test-pipeline",
+				"pipeline.knative.dev/pipelineRun": "test-pipeline-run-success",
+			},
 		},
 		Spec: v1alpha1.TaskRunSpec{
 			ServiceAccount: "test-sa",

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/knative/build-pipeline/pkg/apis/pipeline"
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	knativetest "github.com/knative/pkg/test"
@@ -169,9 +170,18 @@ func TestPipelineRun(t *testing.T) {
 				r, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
-				} else {
-					if !r.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsTrue() {
-						t.Fatalf("Expected TaskRun %s to have succeeded but Status is %v", taskRunName, r.Status)
+				}
+				if !r.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsTrue() {
+					t.Fatalf("Expected TaskRun %s to have succeeded but Status is %v", taskRunName, r.Status)
+				}
+				for name, key := range map[string]string{
+					hwPipelineRunName: pipeline.PipelineRunLabelKey,
+					hwPipelineName: pipeline.PipelineLabelKey,
+				} {
+					expectedName := getName(name, i)
+					lbl := pipeline.GroupName+key
+					if val := r.Labels[lbl]; val != expectedName {
+						t.Errorf("Expected label %s=%s but got %s", lbl, expectedName, val)
 					}
 				}
 			}


### PR DESCRIPTION
Adds labels to TaskRuns created by PipelineRuns as well as Builds that
are created. In TaskRuns and Builds will have labels set telling which
Pipeline, PipelineRun and TaskRun are the owners of it.

This is useful when doing filtering in searches.

Fixes #69