### PR TITLE
Add Description and Default fields to TaskParams

### DIFF
--- a/docs/task-parameters.md
+++ b/docs/task-parameters.md
@@ -21,15 +21,15 @@ kind: Task
 metadata:
   name: task-with-parameters
 spec:
-    inputs:
-        params:
-        - name: flags
-          value: string
-    buildSpec:
-        steps:
-        - name: build
-          image: my-builder
-          args: ['build', '--flags=${inputs.params.flags}']
+  inputs:
+    params:
+    - name: flags
+      value: string
+  buildSpec:
+    steps:
+    - name: build
+      image: my-builder
+      args: ['build', '--flags=${inputs.params.flags}']
 ```
 
 The following `TaskRun` supplies a value for `flags`:
@@ -40,10 +40,10 @@ kind: TaskRun
 metadata:
   name: run-with-parameters
 spec:
-    taskRef:
-        name: task-with-parameters
-    inputs:
-        params:
-        - name: 'flags'
-          value: 'foo=bar,baz=bat'
+  taskRef:
+  name: task-with-parameters
+  inputs:
+    params:
+    - name: 'flags'
+      value: 'foo=bar,baz=bat'
 ```

--- a/docs/using.md
+++ b/docs/using.md
@@ -38,7 +38,7 @@ need.
 * The `passedConstraints` allows for `Tasks` to fan in and fan out, and ordering can be
   expressed explicitly using this key since a task needing a resource from a another
   task would have to run after.
-* The name used in the `passedConstraints` is the name of `PipelineTask`  
+* The name used in the `passedConstraints` is the name of `PipelineTask`
 
 ## Creating a Task
 
@@ -96,14 +96,20 @@ steps:
 
 ### Templating
 
-Tasks support templating using values from all `inputs` and `outputs`.
+Tasks support templating using values from all `inputs` and `outputs`. Both
+`Resources` and `Params` can be used inside the `BuildSpec` of a `Task`.
 
-For example `Resources` can be referenced in a `Task` spec like this,
-where `NAME` is the Resource Name and `KEY` is one of `name`, `url`, `type` or
-`revision`:
+`Resources` can be referenced in a `Task` spec like this, where `NAME` is the
+Resource Name and `KEY` is one of `name`, `url`, `type` or `revision`:
 
 ```shell
 ${inputs.resources.NAME.KEY}
+```
+
+To access a `Param`, replace `resources` with `params` as below:
+
+```shell
+${inputs.params.NAME}
 ```
 
 ## Running a Pipeline

--- a/examples/build_task.yaml
+++ b/examples/build_task.yaml
@@ -4,22 +4,24 @@ metadata:
   name: build-push
   namespace: default
 spec:
-    inputs:
-        resources:
-            - name: workspace
-              type: git
-        params:
-            - name: pathToDockerFile
-    outputs:
-        resources:
-            - name: builtImage
-              type: image
-    buildSpec:
-          steps:
-          - name: build-and-push
-            image: gcr.io/kaniko-project/executor
-            command:
-            - /kaniko/executor
-            args:
-            - --dockerfile=${pathToDockerFile}
-            - --destination=$builtImage
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    params:
+    - name: pathToDockerFile
+      description: The path to the dockerfile to build
+      default: /workspace/Dockerfile
+  outputs:
+    resources:
+    - name: builtImage
+      type: image
+  buildSpec:
+    steps:
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor
+      command:
+      - /kaniko/executor
+      args:
+      - --dockerfile=${pathToDockerFile}
+      - --destination=$builtImage

--- a/examples/deploy_tasks.yaml
+++ b/examples/deploy_tasks.yaml
@@ -10,8 +10,11 @@ spec:
                 type: git
         params:
             - name: pathToHelmCharts
+              description: Path to where the Helm charts live
             - name: helmArgs
+              description: Extra arguments to pass to Helm
             - name: image
+              description: The image to override the Helm chart with
         clusters:
             - name: targetCluster
     buildSpec:
@@ -34,7 +37,9 @@ spec:
               type: git
         params:
             - name: kubectlArgs
+              description: Extra arguments to pass to kubectl
             - name: pathToFiles
+              description: Path to the manifests to apply
         clusters:
             - name: targetCluster
     buildSpec:

--- a/examples/test_tasks.yaml
+++ b/examples/test_tasks.yaml
@@ -10,6 +10,7 @@ spec:
             type: git
         params:
           - name: makeTarget
+            description: The target to have make run
     outputs:
         results:
             - name: testResults
@@ -35,8 +36,11 @@ spec:
              type: git
         params:
             - name: testImage
+              description: The image to use while running the test
             - name: testCommand
+              description: The command to run on the image
             - name: testArgs
+              description: The arguments to pass to the image
     outputs:
         results:
             - name: testResults

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -81,6 +81,10 @@ type Inputs struct {
 // such as resources.
 type TaskParam struct {
 	Name string `json:"name"`
+	// +optional
+	Description string `json:"description,omitempty"`
+	// +optional
+	Default string `json:"default,omitempty"`
 }
 
 // Param declares a value to use for the Param called Name.

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -53,6 +53,13 @@ func TestTaskSpec_Validate(t *testing.T) {
 			fields: fields{
 				Inputs: &Inputs{
 					Resources: []TaskResource{validResource},
+					Params: []TaskParam{
+						{
+							Name:        "task",
+							Description: "param",
+							Default:     "default",
+						},
+					},
 				},
 				BuildSpec: validBuild,
 			},

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -102,15 +102,15 @@ type TaskRunStatus struct {
 func (tr *TaskRunStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {
 	return taskRunCondSet.Manage(tr).GetCondition(t)
 }
-func (ts *TaskRunStatus) InitializeConditions() {
-	taskRunCondSet.Manage(ts).InitializeConditions()
+func (tr *TaskRunStatus) InitializeConditions() {
+	taskRunCondSet.Manage(tr).InitializeConditions()
 }
 
 // SetCondition sets the condition, unsetting previous conditions with the same
 // type as necessary.
-func (ts *TaskRunStatus) SetCondition(newCond *duckv1alpha1.Condition) {
+func (tr *TaskRunStatus) SetCondition(newCond *duckv1alpha1.Condition) {
 	if newCond != nil {
-		taskRunCondSet.Manage(ts).SetCondition(*newCond)
+		taskRunCondSet.Manage(tr).SetCondition(*newCond)
 	}
 }
 
@@ -149,7 +149,7 @@ type TaskRunList struct {
 	Items           []TaskRun `json:"items"`
 }
 
-func (t *TaskRun) SetDefaults() {}
+func (tr *TaskRun) SetDefaults() {}
 
 // GetBuildRef for task
 func (tr *TaskRun) GetBuildRef() corev1.ObjectReference {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (t *TaskRun) Validate() *apis.FieldError {
-	if err := validateObjectMetadata(t.GetObjectMeta()).ViaField("metadata"); err != nil {
+func (tr *TaskRun) Validate() *apis.FieldError {
+	if err := validateObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
-	return t.Spec.Validate()
+	return tr.Spec.Validate()
 }
 
 func (ts *TaskRunSpec) Validate() *apis.FieldError {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -91,8 +91,10 @@ func TestReconcile(t *testing.T) {
 				}},
 				Params: []v1alpha1.TaskParam{{
 					Name: "foo",
+					Description: "foo",
 				}, {
 					Name: "bar",
+					Description: "bar",
 				}},
 			},
 			Outputs: &v1alpha1.Outputs{

--- a/pkg/reconciler/v1alpha1/pipelinerun/validate_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/validate_test.go
@@ -151,8 +151,10 @@ func Test_InvalidPipelineTask(t *testing.T) {
 			Inputs: &v1alpha1.Inputs{
 				Params: []v1alpha1.TaskParam{{
 					Name: "foo",
+					Description: "foo",
 				}, {
 					Name: "bar",
+					Description: "bar",
 				}},
 			},
 		},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -115,6 +115,7 @@ func TestApplyParameters(t *testing.T) {
 	type args struct {
 		b  *buildv1alpha1.Build
 		tr *v1alpha1.TaskRun
+		dp []v1alpha1.TaskParam
 	}
 	tests := []struct {
 		name string
@@ -131,10 +132,27 @@ func TestApplyParameters(t *testing.T) {
 				b.Spec.Steps[0].Image = "bar"
 			}),
 		},
+		{
+			name: "with default parameter",
+			args: args{
+				b:  simpleBuild,
+				tr: &v1alpha1.TaskRun{},
+				dp: []v1alpha1.TaskParam{
+					{
+						Name: "myimage",
+						Default: "mydefault",
+					},
+				},
+
+			},
+			want: applyMutation(simpleBuild, func(b *buildv1alpha1.Build) {
+				b.Spec.Steps[0].Image = "mydefault"
+			}),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ApplyParameters(tt.args.b, tt.args.tr)
+			got := ApplyParameters(tt.args.b, tt.args.tr, tt.args.dp...)
 			if d := cmp.Diff(got, tt.want); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", d)
 			}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -19,7 +19,7 @@ package resources
 import (
 	"fmt"
 
-	v1alpha1 "github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	listers "github.com/knative/build-pipeline/pkg/client/listers/pipeline/v1alpha1"
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	"go.uber.org/zap"
@@ -70,6 +70,9 @@ func AddInputResource(
 			// TODO(#123) support mulitple git inputs
 			break
 		}
+	}
+	if gitResource == nil {
+		return build, nil
 	}
 
 	gitSourceSpec := &buildv1alpha1.GitSourceSpec{

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -328,8 +328,12 @@ func (c *Reconciler) createBuild(tr *v1alpha1.TaskRun, pvcName string) (*buildv1
 		return nil, fmt.Errorf("failed to create a build for taskrun: %s due to input resource error %v", tr.Name, err)
 	}
 
+	var defaults []v1alpha1.TaskParam
+	if t.Spec.Inputs != nil {
+		defaults = append(defaults, t.Spec.Inputs.Params...)
+	}
 	// Apply parameter templating from the taskrun.
-	build = resources.ApplyParameters(build, tr)
+	build = resources.ApplyParameters(build, tr, defaults...)
 
 	// Apply bound resource templating from the taskrun.
 	build, err = resources.ApplyResources(build, tr.Spec.Inputs.Resources, c.resourceLister.PipelineResources(t.Namespace), "inputs")

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -220,7 +220,8 @@ func getHelmDeployTask(namespace string) *v1alpha1.Task {
 					},
 				},
 				Params: []v1alpha1.TaskParam{{
-					Name: "pathToHelmCharts",
+					Name:        "pathToHelmCharts",
+					Description: "Path to the helm charts",
 				}, {
 					Name: "image",
 				}, {


### PR DESCRIPTION
This commit adds the `Description` and `Default` fields to the
TaskParams object. Description is a mandatory field to be used for
describing what the Param is. Default is optional, and may be used to
specify a default value for the param.

Adding these fields will make the pipeline easier to understand.

Also fixes a bug in `resources.AddInputResources` where if the Task has
Inputs defined, AddInputResources assumes there *must* be one of type
GitResource, which is not necessarily the case.

Fixes #190