### PR TITLE
TaskRun Validation - Controller Side

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 )
 
+// Validate taskrun
 func (tr *TaskRun) Validate() *apis.FieldError {
 	if err := validateObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
@@ -31,6 +32,7 @@ func (tr *TaskRun) Validate() *apis.FieldError {
 	return tr.Spec.Validate()
 }
 
+// Validate taskrun spec
 func (ts *TaskRunSpec) Validate() *apis.FieldError {
 	if equality.Semantic.DeepEqual(ts, &TaskRunSpec{}) {
 		return apis.ErrMissingField("spec")
@@ -130,7 +132,6 @@ func (r TaskTriggerRef) Validate(path string) *apis.FieldError {
 
 		if taskType == allowedType {
 			if allowedType == strings.ToLower(string(TaskTriggerTypePipelineRun)) && r.Name == "" {
-				fmt.Println("HERE")
 				return apis.ErrMissingField(fmt.Sprintf("%s.name", path))
 			}
 			return nil

--- a/pkg/reconciler/v1alpha1/pipelinerun/validate_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/validate_test.go
@@ -24,7 +24,7 @@ func Test_InvalidPipelineTask(t *testing.T) {
 				InputSourceBindings: []v1alpha1.SourceBinding{{
 					Name: "test-resource-name",
 					ResourceRef: v1alpha1.PipelineResourceRef{
-						Name: "non-exitent-resource1",
+						Name: "non-existent-resource1",
 					},
 				}},
 			}},
@@ -41,7 +41,7 @@ func Test_InvalidPipelineTask(t *testing.T) {
 				OutputSourceBindings: []v1alpha1.SourceBinding{{
 					Name: "test-resource-name",
 					ResourceRef: v1alpha1.PipelineResourceRef{
-						Name: "non-exitent-resource",
+						Name: "non-existent-resource",
 					},
 				}},
 			}},

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -170,9 +170,9 @@ var defaultTemplatedTask = &v1alpha1.Task{
 		Inputs: &v1alpha1.Inputs{
 			Params: []v1alpha1.TaskParam{
 				{
-					Name: "myarg",
+					Name:        "myarg",
 					Description: "mydesc",
-					Default: "mydefault",
+					Default:     "mydefault",
 				},
 			},
 		},
@@ -292,18 +292,18 @@ func TestReconcile(t *testing.T) {
 								APIVersion: "a1",
 							},
 							Version: "myversion",
-							Name: "workspace",
+							Name:    "workspace",
 						},
 					},
 				},
 				Outputs: v1alpha1.TaskRunOutputs{
 					Resources: []v1alpha1.TaskRunResourceVersion{{
 						ResourceRef: v1alpha1.PipelineResourceRef{
-							Name: "image-resource",
+							Name:       "image-resource",
 							APIVersion: "a1",
 						},
 						Version: "myversion",
-						Name: "myimage",
+						Name:    "myimage",
 					}},
 				},
 			},
@@ -332,7 +332,7 @@ func TestReconcile(t *testing.T) {
 								APIVersion: "a1",
 							},
 							Version: "myversion",
-							Name: gitResource.Name,
+							Name:    gitResource.Name,
 						},
 					},
 				},
@@ -356,7 +356,7 @@ func TestReconcile(t *testing.T) {
 								APIVersion: "a1",
 							},
 							Version: "myversion",
-							Name: gitResource.Name,
+							Name:    gitResource.Name,
 						},
 					},
 				},
@@ -552,7 +552,6 @@ func TestReconcile(t *testing.T) {
 			if err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun)); err != nil {
 				t.Errorf("expected no error. Got error %v", err)
 			}
-
 			if len(clients.Build.Actions()) == 0 {
 				t.Errorf("Expected actions to be logged in the buildclient, got none")
 			}
@@ -644,7 +643,7 @@ func TestReconcile_InvalidTaskRuns(t *testing.T) {
 		{
 			name:    "task run with no task",
 			taskRun: taskRuns[0],
-			reason:  taskrun.ReasonCouldntGetTask,
+			reason:  taskrun.ReasonFailedValidation,
 		},
 	}
 
@@ -658,8 +657,8 @@ func TestReconcile_InvalidTaskRuns(t *testing.T) {
 			if err != nil {
 				t.Errorf("Did not expect to see error when reconciling invalid TaskRun but saw %q", err)
 			}
-			if len(clients.Build.Actions()) != 1 {
-				t.Errorf("expected no actions to be created by the reconciler, got %v", clients.Build.Actions())
+			if len(clients.Build.Actions()) != 0 {
+				t.Errorf("expected no actions created by the reconciler, got %v", clients.Build.Actions())
 			}
 			// Since the TaskRun is invalid, the status should say it has failed
 			condition := tc.taskRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded)

--- a/pkg/reconciler/v1alpha1/taskrun/validate.go
+++ b/pkg/reconciler/v1alpha1/taskrun/validate.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either extress or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"fmt"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// validate all references in taskrun exist at runtime
+func validateTaskRun(c *Reconciler, tr *v1alpha1.TaskRun) error {
+	// verify task reference exists, all params are provided
+	// and all inputs/outputs are bound
+	t, err := c.taskLister.Tasks(tr.Namespace).Get(tr.Spec.TaskRef.Name)
+	if err != nil {
+		return fmt.Errorf("Error listing task ref %s: %v",
+			tr.Spec.TaskRef.Name, err)
+	}
+	return validateTaskRunAndTask(c, *tr, t, tr.Namespace)
+}
+
+//validateTaskRunTask validates task inputs, params and output matches taskrun
+func validateTaskRunAndTask(c *Reconciler, tr v1alpha1.TaskRun, task *v1alpha1.Task, ns string) error {
+	// stores all the input keys to validate with task input name
+	inputMapping := map[string]string{}
+	// stores all the output keys to validate with task output name
+	outMapping := map[string]string{}
+	// stores params to validate with task params
+	paramsMapping := map[string]string{}
+
+	for _, param := range tr.Spec.Inputs.Params {
+		paramsMapping[param.Name] = ""
+	}
+
+	for _, source := range tr.Spec.Inputs.Resources {
+		inputMapping[source.Name] = ""
+		if source.ResourceRef.Name != "" {
+			rr, err := c.resourceLister.PipelineResources(ns).Get(
+				source.ResourceRef.Name)
+			if err != nil {
+				return fmt.Errorf("Error listing input task resource "+
+					"for task %s: %v ", tr.Name, err)
+			}
+			inputMapping[source.Name] = string(rr.Spec.Type)
+		}
+	}
+	for _, source := range tr.Spec.Outputs.Resources {
+		outMapping[source.Name] = ""
+		if source.ResourceRef.Name != "" {
+			rr, err := c.resourceLister.PipelineResources(ns).Get(
+				source.ResourceRef.Name)
+			if err != nil {
+				return fmt.Errorf("Error listing output task resource "+
+					"for task %s: %v ", tr.Name, err)
+			}
+			outMapping[source.Name] = string(rr.Spec.Type)
+
+		}
+	}
+
+	if task.Spec.Inputs != nil {
+		for _, inputResource := range task.Spec.Inputs.Resources {
+			inputResourceType, ok := inputMapping[inputResource.Name]
+			if !ok {
+				return fmt.Errorf("Mismatch of input key %q between "+
+					"task %q and task %q", inputResource.Name,
+					tr.Name, task.Name)
+			}
+			// Validate the type of resource match
+			if string(inputResource.Type) != inputResourceType {
+				return fmt.Errorf("Mismatch of input resource type %q "+
+					"between task %q and task %q", inputResourceType,
+					tr.Name, task.Name)
+			}
+		}
+		for _, inputResourceParam := range task.Spec.Inputs.Params {
+			if _, ok := paramsMapping[inputResourceParam.Name]; !ok {
+				if inputResourceParam.Default == "" {
+					return fmt.Errorf("Mismatch of input params %q between "+
+						"task %q and task %q", inputResourceParam.Name, tr.Name,
+						task.Name)
+				}
+			}
+		}
+	}
+
+	if task.Spec.Outputs != nil {
+		for _, outputResource := range task.Spec.Outputs.Resources {
+			outputResourceType, ok := outMapping[outputResource.Name]
+			if !ok {
+				return fmt.Errorf("Mismatch of output key %q between "+
+					"task %q and task %q", outputResource.Name,
+					tr.Name, task.Name)
+			}
+			// Validate the type of resource match
+			if string(outputResource.Type) != outputResourceType {
+				return fmt.Errorf("Mismatch of output resource type %q "+
+					"between task %q and task %q", outputResourceType,
+					tr.Name, task.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/v1alpha1/taskrun/validate_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/validate_test.go
@@ -1,0 +1,362 @@
+package taskrun_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/test"
+	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var validBuild = &buildv1alpha1.BuildSpec{
+	Steps: []corev1.Container{
+		{
+			Name:  "mystep",
+			Image: "myimage",
+		},
+	},
+}
+
+func Test_ValidTaskRunTask(t *testing.T) {
+	trs := []*v1alpha1.TaskRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "taskrun-valid-input",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "task-valid-input",
+			},
+			Inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "resource-to-build",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "example-resource",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	ts := []*v1alpha1.Task{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "task-valid-input",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			BuildSpec: validBuild,
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{
+					Name: "resource-to-build",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+			},
+		},
+	}}
+
+	rr := []*v1alpha1.PipelineResource{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-resource",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeGit,
+			Params: []v1alpha1.Param{{
+				Name:  "foo",
+				Value: "bar",
+			}},
+		},
+	}}
+
+	tcs := []struct {
+		name    string
+		taskrun *v1alpha1.TaskRun
+		reason  string
+	}{
+		{
+			name:    "taskrun-valid-input",
+			taskrun: trs[0],
+			reason:  "taskrun-with-valid-inputs",
+		}}
+
+	for i, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				TaskRuns:          []*v1alpha1.TaskRun{trs[i]},
+				Tasks:             ts,
+				PipelineResources: rr,
+			}
+
+			c, _, _ := test.GetTaskRunController(d)
+			err := c.Reconciler.Reconcile(context.Background(),
+				fmt.Sprintf("%s/%s", tc.taskrun.Namespace, tc.taskrun.Name))
+
+			if err != nil {
+				t.Errorf("Did not expect to see error when reconciling invalid task but saw %q", err)
+			}
+			condition := trs[i].Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+			if condition == nil || condition.Status == corev1.ConditionFalse {
+				t.Errorf("Valid task %s failed with condition %s, expected no failure", tc.taskrun.Name, condition)
+			}
+		})
+	}
+}
+
+func Test_InvalidTaskRunTask(t *testing.T) {
+	trs := []*v1alpha1.TaskRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-bad-task-input-resourceref",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-test-task",
+			},
+			Inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "test-resource-name",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "non-existent-resource1",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-bad-task-output-resourceref",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-test-task",
+			},
+			Outputs: v1alpha1.TaskRunOutputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "test-resource-name",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "non-existent-resource1",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-bad-inputkey",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-test-wrong-input",
+			},
+			Inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "test-resource-name",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "non-existent",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-bad-outputkey",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-test-task",
+			},
+			Outputs: v1alpha1.TaskRunOutputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "test-resource-name",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "non-existent",
+						},
+					},
+				},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-param-mismatch",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-task-multiple-params",
+			},
+			Inputs: v1alpha1.TaskRunInputs{
+				Params: []v1alpha1.Param{
+					v1alpha1.Param{
+						Name:  "foobar",
+						Value: "somethingfun",
+					},
+				},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-bad-resourcetype",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: v1alpha1.TaskRef{
+				Name: "unit-task-bad-resourcetype",
+			},
+			Inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskRunResourceVersion{
+					v1alpha1.TaskRunResourceVersion{
+						Name: "testimageinput",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "git-test-resource",
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	ts := []*v1alpha1.Task{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-test-task",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-task-wrong-input",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{
+					Name: "testinput",
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-task-wrong-output",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{{
+					Name: "testoutput",
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-task-multiple-params",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			Inputs: &v1alpha1.Inputs{
+				Params: []v1alpha1.TaskParam{{
+					Name: "foo",
+				}, {
+					Name: "bar",
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "unit-task-bad-resourcetype",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskSpec{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{
+					Name: "testimageinput",
+					Type: v1alpha1.PipelineResourceTypeImage,
+				}},
+			},
+		},
+	}}
+
+	rr := []*v1alpha1.PipelineResource{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "git-test-resource",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeGit,
+			Params: []v1alpha1.Param{{
+				Name:  "foo",
+				Value: "bar",
+			}},
+		},
+	}}
+
+	tcs := []struct {
+		name    string
+		taskrun *v1alpha1.TaskRun
+		reason  string
+	}{
+		{
+			name:    "bad-input-source-bindings",
+			taskrun: trs[0],
+			reason:  "input-source-binding-to-invalid-resource",
+		}, {
+			name:    "bad-output-source-bindings",
+			taskrun: trs[1],
+			reason:  "output-source-binding-to-invalid-resource",
+		}, {
+			name:    "bad-inputkey",
+			taskrun: trs[2],
+			reason:  "bad-input-mapping",
+		}, {
+			name:    "bad-outputkey",
+			taskrun: trs[3],
+			reason:  "bad-output-mapping",
+		}, {
+			name:    "param-mismatch",
+			taskrun: trs[4],
+			reason:  "input-param-mismatch",
+		}, {
+			name:    "resource-mismatch",
+			taskrun: trs[5],
+			reason:  "input-resource-mismatch",
+		}}
+
+	for i, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				TaskRuns:          []*v1alpha1.TaskRun{trs[i]},
+				Tasks:             ts,
+				PipelineResources: rr,
+			}
+
+			c, _, _ := test.GetTaskRunController(d)
+			err := c.Reconciler.Reconcile(context.Background(),
+				fmt.Sprintf("%s/%s", tc.taskrun.Namespace, tc.taskrun.Name))
+
+			if err != nil {
+				t.Errorf("Did not expect to see error when reconciling invalid task but saw %q", err)
+			}
+			condition := trs[i].Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+			if condition == nil || condition.Status != corev1.ConditionFalse {
+				t.Errorf("Expected status to be failed on invalid task %s but was: %v", tc.taskrun.Name, condition)
+			}
+		})
+	}
+}

--- a/test/controller.go
+++ b/test/controller.go
@@ -73,20 +73,20 @@ type Informers struct {
 
 func seedTestData(d Data) (Clients, Informers) {
 	objs := []runtime.Object{}
-	for _, pr := range d.PipelineRuns {
-		objs = append(objs, pr)
+	for _, r := range d.PipelineResources {
+		objs = append(objs, r)
 	}
 	for _, p := range d.Pipelines {
 		objs = append(objs, p)
 	}
-	for _, tr := range d.TaskRuns {
-		objs = append(objs, tr)
+	for _, pr := range d.PipelineRuns {
+		objs = append(objs, pr)
 	}
 	for _, t := range d.Tasks {
 		objs = append(objs, t)
 	}
-	for _, r := range d.PipelineResources {
-		objs = append(objs, r)
+	for _, tr := range d.TaskRuns {
+		objs = append(objs, tr)
 	}
 
 	buildObjs := []runtime.Object{}

--- a/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
+++ b/vendor/github.com/knative/pkg/apis/duck/v1alpha1/conditions_types.go
@@ -93,7 +93,6 @@ func (c *Condition) IsUnknown() bool {
 	return c.Status == corev1.ConditionUnknown
 }
 
-
 // Conditions is an Implementable "duck type".
 var _ duck.Implementable = (*Conditions)(nil)
 


### PR DESCRIPTION
What is the problem being solved?
Fixes #188, TaskRun Validation - Controller Side.  This PR adds additional TaskRun validation to the TaskRun controller which checks that referenced Params and Resources exist and that they are bound properly from the Task.

Why is this the best approach?
This approach follows the style and convention for a similar issues, #162, PipelineRun validation.

What other approaches did you consider?
N/A

What side effects will this approach have?
It is possible that some demo/sample yaml which use to execute will no longer work as we have this additional validation.

What future work remains to be done?
For the TaskRun controller, I believe that this validation is sufficient.  In the future we should extend validation to all of our primitive types, especially PipelineResource.