### PR TITLE
Add `command` to `Task.BuildSep.Steps` in all example…

### DIFF
--- a/examples/build_task.yaml
+++ b/examples/build_task.yaml
@@ -18,6 +18,8 @@ spec:
           steps:
           - name: build-and-push
             image: gcr.io/kaniko-project/executor
+            command:
+            - /kaniko/executor
             args:
             - --dockerfile=${pathToDockerFile}
             - --destination=$builtImage

--- a/examples/deploy_tasks.yaml
+++ b/examples/deploy_tasks.yaml
@@ -18,6 +18,7 @@ spec:
         steps:
         - name: deploy
           image: kubernetes-helm
+          command: ['helm']
           args: ['install', '--kube-context=${targetCluster}', '--set image=${image}', '${helmArgs}', '${pathToHelmChart}']
 
 ---
@@ -40,4 +41,5 @@ spec:
         steps:
         - name: runKubectl
           image: k8s-kubectl
+          command: ['kubectl']
           args: ['--use-context', '${targetCluster}', '--namespace', '${targetCluster.namespace}', 'apply', '-c', '${pathToFiles}', '${kubectlArgs}']

--- a/examples/pipelines/guestbook.yaml
+++ b/examples/pipelines/guestbook.yaml
@@ -56,7 +56,7 @@ spec:
                 key: testCluster
         - name: int-test-osx                    # 3.a Run Integration tests for osx
           taskRef:
-              name: integrationTestInDocker
+              name: integration-test-in-docker
           inputSourceBindings:
               - name: workspace
                 resourceRef:

--- a/examples/test_tasks.yaml
+++ b/examples/test_tasks.yaml
@@ -19,7 +19,8 @@ spec:
         steps:
             - name: runMake
               image: ubuntu
-              args: ['make', '${makeTarget}']
+              command: ['make']
+              args: ['${makeTarget}']
 
 ---
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -34,6 +35,7 @@ spec:
              type: git
         params:
             - name: testImage
+            - name: testCommand
             - name: testArgs
     outputs:
         results:
@@ -44,6 +46,7 @@ spec:
         steps:
             - name: runTests
               image: '${testImage}'
+              command: ['${testCommand}']
               args: ['${testArgs}']
               volumeMounts:
               - name: gac


### PR DESCRIPTION
… also the guestbook `integrationTestInDocker` taskref name.

Fixes #202 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>