### PR TITLE
Run PipelineRun tests in parallel

### DIFF
--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -29,7 +29,6 @@ import (
 	buildv1alpha1 "github.com/knative/build/pkg/apis/build/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	knativetest "github.com/knative/pkg/test"
-	"github.com/knative/pkg/test/logging"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -134,7 +133,7 @@ func TestPipelineRun(t *testing.T) {
 			// Note that getting a new logger has the side effect of setting the global metrics logger as well,
 			// this means that metrics emitted from these tests will have the wrong test name attached. We should
 			// revisit this if we ever start using those metrics (maybe use a different metrics gatherer).
-			logger := logging.GetContextLogger(t.Name())
+			logger := getContextLogger(t.Name())
 			c, namespace := setup(t, logger)
 
 			knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
@@ -178,10 +177,10 @@ func TestPipelineRun(t *testing.T) {
 				}
 				for name, key := range map[string]string{
 					hwPipelineRunName: pipeline.PipelineRunLabelKey,
-					hwPipelineName: pipeline.PipelineLabelKey,
+					hwPipelineName:    pipeline.PipelineLabelKey,
 				} {
 					expectedName := getName(name, i)
-					lbl := pipeline.GroupName+key
+					lbl := pipeline.GroupName + key
 					if val := r.Labels[lbl]; val != expectedName {
 						t.Errorf("Expected label %s=%s but got %s", lbl, expectedName, val)
 					}


### PR DESCRIPTION
In https://github.com/knative/build-pipeline/pull/197 @shashwathi
updated the pipelineRun tests so that they could be run as table driven
tests. By making it so that each subtest creates its own namespace and
logger, we can run the tests in parllel. They will not interfere with
each other, and log messages will be interweaved, but the logger will be
named after the tests so it will be possible to reconstruct which log
message is from which test.

One side effect of this is that the metrics gathering piece is global,
so we cannot trust metrics which are emitted from these tests. I
considered making a follow-up ticket to address this, but since we
aren't using these metrics at all currently it seemed premature.

Running the tests in parallel reduces the time these tests take to run
by ~ half, e.g. from 180 seconds to 70-100 seconds in my runs.