### PR TITLE
Remove status section for CRD definitions

### DIFF
--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -16,8 +16,3 @@ spec:
     - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/config/300-pipelineparams.yaml
+++ b/config/300-pipelineparams.yaml
@@ -13,11 +13,6 @@ spec:
     categories:
     - all
     - knative
-    - build-pipeline    
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -13,11 +13,6 @@ spec:
     categories:
     - all
     - knative
-    - build-pipeline    
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -13,11 +13,6 @@ spec:
     categories:
     - all
     - knative
-    - build-pipeline    
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -13,11 +13,6 @@ spec:
     categories:
     - all
     - knative
-    - build-pipeline    
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -13,11 +13,6 @@ spec:
     categories:
     - all
     - knative
-    - build-pipeline    
+    - build-pipeline
   scope: Namespaced
   version: v1alpha1
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null


### PR DESCRIPTION
As of k8s 1.11, backwards incompatible changes have been made to the
`status` section of a CRD definition:
* conditions can no longer be null
* storedVersions is now required

These types were generated with an old version of kubebuilder (note this
has been recently fixed
https://github.com/kubernetes-sigs/controller-tools/commit/e1e18d80b1b4e0657e367ef4571e0ccdbeb3c298)
and so these fields were incorrect.

Since we're not actually providing any values for these fields, I'm just
removing them (which matches how custom resources are defined in
`knative/serving` and `knative/build`.

This works for both 1.10 clusters and 1.11.

Fixes #225 