### PR TITLE
Rename passedConstraints to providedBy

### DIFF
--- a/docs/cuj/exercises/exercise2/hipster-pipeline.yaml
+++ b/docs/cuj/exercises/exercise2/hipster-pipeline.yaml
@@ -54,7 +54,7 @@ spec:
           - name: workspace
             resourceRef:
               name: hipster-source
-            passedConstraints:
+            providedBy:
               - build-checkoutservice
               - build-productcatalog
               - build-frontend

--- a/docs/using.md
+++ b/docs/using.md
@@ -16,29 +16,29 @@
    to run against, where to store results, etc.
 3. Create a `Pipeline` which expresses the Tasks you would like to run and what
    [Resources](#creating-resources) the Tasks need.
-   Use [`passedConstraints`](#passedconstraints) to express the order the `Tasks` should run in.
+   Use [`providedBy`](#providedBy) to express the order the `Tasks` should run in.
 
 See [the example guestbook Pipeline](../examples/pipelines/guestbook.yaml) and
 [the example kritis Pipeline](../examples/pipelines/kritis.yaml).
 
-### PassedConstraints
+### ProvidedBy
 
 When you need to execute `Tasks` in a particular order, it will likely be because they
 are operating over the same `Resources` (e.g. your unit test task must run first against
 your git repo, then you build an image from that repo, then you run integration tests
 against that image).
 
-We express this ordering by adding `passedConstraints` on `Resources` that our `Tasks`
+We express this ordering by adding `providedBy` on `Resources` that our `Tasks`
 need.
 
-* The (optional) `passedConstraints` key on an `input source` defines a set of previous
+* The (optional) `providedBy` key on an `input source` defines a set of previous
   task names.
-* When the `passedConstraints` key is specified on an input source, only the version of
-  the resource that passed through the defined list of tasks is used.
-* The `passedConstraints` allows for `Tasks` to fan in and fan out, and ordering can be
+* When the `providedBy` key is specified on an input source, only the version of
+  the resource that is provided by the defined list of tasks is used.
+* The `providedBy` allows for `Tasks` to fan in and fan out, and ordering can be
   expressed explicitly using this key since a task needing a resource from a another
   task would have to run after.
-* The name used in the `passedConstraints` is the name of `PipelineTask`
+* The name used in the `providedBy` is the name of `PipelineTask`
 
 ## Creating a Task
 

--- a/examples/pipelines/guestbook.yaml
+++ b/examples/pipelines/guestbook.yaml
@@ -40,12 +40,12 @@ spec:
     - name: imageToDeploy1
       resourceRef:
         name: redisstagingimage
-      passedConstraints:
+      providedBy:
       - build-redis
     - name: imageToDeploy2
       resourceRef:
         name: guestbookstagingimage
-      passedConstraints:
+      providedBy:
       - build-guestbook  
     - name: workspace
       resourceRef:
@@ -63,7 +63,7 @@ spec:
     - name: workspace
       resourceRef:
         name: guestbook-resources-git
-      passedConstraints:
+      providedBy:
       - deploy-bundle-test
     params:
     - name: dockerBuildFile
@@ -75,7 +75,7 @@ spec:
     - name: workspace
       resourceRef:
         name: guestbook-resources-git
-      passedConstraints:
+      providedBy:
       - deploy-bundle-test
     params:
     - name: dockerBuildFile
@@ -87,13 +87,13 @@ spec:
     - name: redisImage
       resourceRef:
         name: redisstagingimage
-      passedConstraints:
+      providedBy:
       - int-test-osx
       - int-test-linux
     - name: guestbookImage
       resourceRef:
         name: guestbookstagingimage
-      passedConstraints:
+      providedBy:
       - int-test-osx
       - int-test-linux
     - name: workspace

--- a/examples/pipelines/kritis.yaml
+++ b/examples/pipelines/kritis.yaml
@@ -22,7 +22,7 @@ spec:
     - name: workspace
       resourceRef:
         name: kritis-resources-git
-      passedConstraints: [unit-test-kritis]
+      providedBy: [unit-test-kritis]
     outputSourceBindings:
     - name: builtImage
       resourceRef:
@@ -40,7 +40,7 @@ spec:
     - name: builtImage
       resourceRef:
         name: kritis-resources-image
-      passedConstraints: [push-kritis]
+      providedBy: [push-kritis]
     - name: testCluster
       resourceRef:
         name: kritistestcluster  
@@ -54,7 +54,7 @@ spec:
     - name: workspace
       resourceRef:
           name: kritis-resources-git
-      passedConstraints: [deploy-test-env]
+      providedBy: [deploy-test-env]
     params:
     - name: testArgs
       value: "-e REMOTE_INTEGRATION=true"

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -84,9 +84,9 @@ type SourceBinding struct {
 	Name string `json:"name"`
 	// The Resource this binding is referring to
 	ResourceRef PipelineResourceRef `json:"resourceRef"`
-	// PassedConstraints is the list of Task names that the resource has to pass through.
+	// ProvidedBy is the list of Task names that the resource has to come from.
 	// +optional
-	PassedConstraints []string `json:"passedConstraints,omitempty"`
+	ProvidedBy []string `json:"providedBy,omitempty"`
 }
 
 // TaskRef can be used to refer to a specific instance of a task.

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -44,10 +44,10 @@ func (ps *PipelineSpec) Validate() *apis.FieldError {
 		taskNames[t.Name] = struct{}{}
 	}
 
-	// passedConstraints should match other tasks.
+	// providedBy should match other tasks.
 	for _, t := range ps.Tasks {
 		for _, isb := range t.InputSourceBindings {
-			for _, pc := range isb.PassedConstraints {
+			for _, pc := range isb.ProvidedBy {
 				if _, ok := taskNames[pc]; !ok {
 					return apis.ErrInvalidKeyName(pc, fmt.Sprintf("spec.tasks.inputSourceBindings.%s", pc))
 				}

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -50,7 +50,7 @@ func TestPipelineSpec_Validate_Error(t *testing.T) {
 						Name: "foo",
 						InputSourceBindings: []SourceBinding{
 							{
-								PassedConstraints: []string{"bar"},
+								ProvidedBy: []string{"bar"},
 							},
 						},
 					},
@@ -101,7 +101,7 @@ func TestPipelineSpec_Validate_Valid(t *testing.T) {
 						Name: "foo",
 						InputSourceBindings: []SourceBinding{
 							{
-								PassedConstraints: []string{"bar"},
+								ProvidedBy: []string{"bar"},
 							},
 						},
 					},

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -754,8 +754,8 @@ func (in *SecretParam) DeepCopy() *SecretParam {
 func (in *SourceBinding) DeepCopyInto(out *SourceBinding) {
 	*out = *in
 	out.ResourceRef = in.ResourceRef
-	if in.PassedConstraints != nil {
-		in, out := &in.PassedConstraints, &out.PassedConstraints
+	if in.ProvidedBy != nil {
+		in, out := &in.ProvidedBy, &out.ProvidedBy
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/pkg/reconciler/v1alpha1/pipeline/resources/dag.go
+++ b/pkg/reconciler/v1alpha1/pipeline/resources/dag.go
@@ -103,10 +103,10 @@ func Build(p *v1alpha1.Pipeline) (*DAG, error) {
 			return nil, errors.NewDuplicatePipelineTask(p, pt.Name)
 		}
 	}
-	// Process all passedConstraints to add task dependency
+	// Process all providedBy constraints to add task dependency
 	for _, pt := range p.Spec.Tasks {
 		for _, input := range pt.InputSourceBindings {
-			for _, constraint := range input.PassedConstraints {
+			for _, constraint := range input.ProvidedBy {
 				// We need to add dependency from constraint to node n
 				prev, ok := d.Nodes[constraint]
 				if !ok {

--- a/pkg/reconciler/v1alpha1/pipeline/resources/dag_test.go
+++ b/pkg/reconciler/v1alpha1/pipeline/resources/dag_test.go
@@ -30,27 +30,27 @@ func TestBuild(t *testing.T) {
 	c := v1alpha1.PipelineTask{Name: "c"}
 	xDependsOnA := v1alpha1.PipelineTask{
 		Name:                "x",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"a"}}},
 	}
 	yDependsOnAB := v1alpha1.PipelineTask{
 		Name:                "y",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"b", "a"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"b", "a"}}},
 	}
 	zDependsOnX := v1alpha1.PipelineTask{
 		Name:                "z",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"x"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"x"}}},
 	}
 	aDependsOnZ := v1alpha1.PipelineTask{
 		Name:                "a",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"z"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"z"}}},
 	}
 	selfLink := v1alpha1.PipelineTask{
 		Name:                "a",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"a"}}},
 	}
 	invalidTask := v1alpha1.PipelineTask{
 		Name:                "a",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"none"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"none"}}},
 	}
 	nodeX := &Node{Task: xDependsOnA, Prev: []*Node{&Node{Task: a}}}
 
@@ -136,11 +136,11 @@ func TestGetPrevTasks(t *testing.T) {
 	a := v1alpha1.PipelineTask{Name: "a"}
 	x := v1alpha1.PipelineTask{
 		Name:                "x",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"a"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"a"}}},
 	}
 	y := v1alpha1.PipelineTask{
 		Name:                "y",
-		InputSourceBindings: []v1alpha1.SourceBinding{{PassedConstraints: []string{"x", "a"}}},
+		InputSourceBindings: []v1alpha1.SourceBinding{{ProvidedBy: []string{"x", "a"}}},
 	}
 	p := v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinestate.go
@@ -70,8 +70,8 @@ func GetNextTask(prName string, state []*PipelineRunTaskRun, logger *zap.Sugared
 func canTaskRun(pt *v1alpha1.PipelineTask, state []*PipelineRunTaskRun) bool {
 	// Check if Task can run now. Go through all the input constraints
 	for _, input := range pt.InputSourceBindings {
-		if len(input.PassedConstraints) > 0 {
-			for _, constrainingTaskName := range input.PassedConstraints {
+		if len(input.ProvidedBy) > 0 {
+			for _, constrainingTaskName := range input.ProvidedBy {
 				for _, prtr := range state {
 					// the constraining task must have a successful task run to allow this task to run
 					if prtr.PipelineTask.Name == constrainingTaskName {

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/providedby_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/providedby_test.go
@@ -76,7 +76,7 @@ var mypipelinetasks = []v1alpha1.PipelineTask{{
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "myresource1",
 		},
-		PassedConstraints: []string{"mypipelinetask1"},
+		ProvidedBy: []string{"mypipelinetask1"},
 	}},
 }}
 

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -273,7 +273,7 @@ func getHelmDeployPipeline(namespace string) *v1alpha1.Pipeline {
 						ResourceRef: v1alpha1.PipelineResourceRef{
 							Name: sourceResourceName,
 						},
-						PassedConstraints: []string{createImageTaskName},
+						ProvidedBy: []string{createImageTaskName},
 					}},
 					Params: []v1alpha1.Param{{
 						Name:  "pathToHelmCharts",


### PR DESCRIPTION
Fixes: #137
 
Since the "passedConstraint" flag is for indicating that the task should  use that input resource coming from the task(s) in the list, "providedBy" conveys the meaning better

/cc @bobcatfish 