### PR TITLE
Validate Task step name

### DIFF
--- a/examples/deploy_tasks.yaml
+++ b/examples/deploy_tasks.yaml
@@ -52,19 +52,19 @@ spec:
     - name: pathToFiles
       description: Path to the manifests to apply
   steps:
-  - name: replaceRedisImage
+  - name: replace-redis-image
     image: busybox
     command: ['sed']
     args:
     - "-ri"
     - "'s/image: k8s.gcr.io\\/redis:e2e/image: ${inputs.resources.redisImage.url}@{inputs.resources.redisImage.digest}/' ${inputs.params.pathToFiles}"
-  - name: replaceGuestbookImage
+  - name: replace-guestbook-image
     image: busybox
     command: ['sed']
     args:
     - "-ri"
     - "'s/image: gcr.io\\/google-samples\\/gb-frontend:v4/image: ${inputs.resources.guestbookImage.url}@{inputs.resources.guestbookImage.digest}/' ${inputs.params.pathToFiles}"
-  - name: runKubectl
+  - name: run-kubectl
     image: lachlanevenson/k8s-kubectl
     command: ['kubectl']
     args:

--- a/examples/test_tasks.yaml
+++ b/examples/test_tasks.yaml
@@ -17,7 +17,7 @@ spec:
       format: junit
       path: logs/tests.xml
   steps:
-  - name: runMake
+  - name: run-make
     image: ubuntu
     command: ['make']
     args: ['${inputs.params.makeTarget}']
@@ -46,7 +46,7 @@ spec:
       format: junit
       path: integration/logs/tests.xml
   steps:
-  - name: runTests
+  - name: run-tests
     image: docker
     command: ['${inputs.resources.params.testCommand}']
     args: ['${inputs.resources.params.testArgs}']

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/knative/pkg/apis"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func (t *Task) Validate() *apis.FieldError {
@@ -62,6 +63,17 @@ func (ts *TaskSpec) Validate() *apis.FieldError {
 		}
 		if err := checkForDuplicates(ts.Outputs.Resources, "taskspec.Outputs.Resources.Name"); err != nil {
 			return err
+		}
+	}
+
+	// Validate task step names
+	for _, step := range ts.Steps {
+		if errs := validation.IsDNS1123Label(step.Name); len(errs) > 0 {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("invalid value %q", step.Name),
+				Paths:   []string{"taskspec.steps.name"},
+				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			}
 		}
 	}
 	return nil

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -32,6 +32,11 @@ var validBuildSteps = []corev1.Container{{
 	Image: "myimage",
 }}
 
+var invalidBuildSteps = []corev1.Container{{
+	Name:  "replaceImage",
+	Image: "myimage",
+}}
+
 func TestTaskSpec_Validate(t *testing.T) {
 	type fields struct {
 		Inputs  *Inputs
@@ -181,6 +186,14 @@ func TestTaskSpec_ValidateError(t *testing.T) {
 				Resources: []TaskResource{validResource},
 			},
 			BuildSteps: []corev1.Container{},
+		},
+	}, {
+		name: "invalid build step name",
+		fields: fields{
+			Inputs: &Inputs{
+				Resources: []TaskResource{validResource},
+			},
+			BuildSteps: invalidBuildSteps,
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
In this PR, webhook validation is added for task step name. It checks whether step name adheres to qualified DNS label rules.

Fixes : https://github.com/knative/build-pipeline/issues/273