### PR TITLE
Add dep-collector to the list of required tools in Gopkg.toml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -849,6 +849,7 @@
     "github.com/knative/pkg/tracker",
     "github.com/knative/pkg/webhook",
     "github.com/knative/test-infra/scripts",
+    "github.com/knative/test-infra/tools/dep-collector",
     "go.opencensus.io/trace",
     "go.uber.org/zap",
     "go.uber.org/zap/zaptest/observer",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -10,6 +10,7 @@ required = [
   "k8s.io/code-generator/cmd/informer-gen",
   "github.com/knative/caching/pkg/apis/caching",
   "github.com/knative/test-infra/scripts",
+  "github.com/knative/test-infra/tools/dep-collector",
 ]
 
 [[override]]


### PR DESCRIPTION
We need it as a tool, but not its dependencies.

For details, see https://github.com/knative/build/pull/487#issuecomment-443476057