### PR TITLE
Fix typo / copy pasta in example Pipeline

### DIFF
--- a/examples/pipeline.yaml
+++ b/examples/pipeline.yaml
@@ -38,7 +38,7 @@ spec:
   - name: deploy-web
     taskRef:
       name: demo-deploy-kubectl
-    inputSourceBindings:
+    resources:
     - name: image
       providedBy:
       - build-skaffold-web


### PR DESCRIPTION
We renamed `inputSourceBindings` (and `outputSourceBindings`) to
`resources` in #148 where we also moved the specification of these
bindings into the `PipelineRun` - now the `resources` section in the
`Pipeline` itself exists just to specify dependencies between resources.

But we missed one in the example!

Also created #297 to follow up on catching this in validation.

(Thanks for pointing this out @bkuschel!! :heart: )