### PR TITLE
Stop reconciling a PipelineRun once it has completed

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -309,6 +309,5 @@ func getOrCreatePVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) error {
 
 // isDone returns true if the PipelineRun's status indicates the build is done.
 func isDone(status *v1alpha1.PipelineRunStatus) bool {
-	cond := status.GetCondition(duckv1alpha1.ConditionSucceeded)
-	return cond != nil && cond.Status != corev1.ConditionUnknown
+	return !status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
 }

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -257,7 +257,11 @@ func TestReconcile(t *testing.T) {
 		PipelineResources: rs,
 	}
 
-	c, _, clients, informers := test.GetPipelineRunController(d)
+	testAssets := test.GetPipelineRunController(d)
+	c := testAssets.Controller
+	clients := testAssets.Clients
+	informers := testAssets.Informers
+
 	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-success")
 	if err != nil {
 		t.Errorf("Did not expect to see error when reconciling valid Pipeline but saw %s", err)
@@ -476,7 +480,9 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, _, _ := test.GetPipelineRunController(d)
+			testAssets := test.GetPipelineRunController(d)
+			c := testAssets.Controller
+
 			err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.pipelineRun))
 			// When a PipelineRun is invalid and can't run, we don't want to return an error because
 			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
@@ -517,7 +523,10 @@ func TestReconcile_InvalidPipelineRunNames(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			c, logs, _, _ := test.GetPipelineRunController(test.Data{})
+			testAssets := test.GetPipelineRunController(test.Data{})
+			c := testAssets.Controller
+			logs := testAssets.Logs
+
 			err := c.Reconciler.Reconcile(context.Background(), tc.pipelineRun)
 			// No reason to keep reconciling something that doesnt or can't exist
 			if err != nil {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -260,7 +260,6 @@ func TestReconcile(t *testing.T) {
 	testAssets := test.GetPipelineRunController(d)
 	c := testAssets.Controller
 	clients := testAssets.Clients
-	informers := testAssets.Informers
 
 	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-success")
 	if err != nil {
@@ -359,43 +358,6 @@ func TestReconcile(t *testing.T) {
 	}
 	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1"]; exists == false {
 		t.Errorf("Expected PipelineRun status to include TaskRun status")
-	}
-
-	if err := clients.Pipeline.Pipeline().TaskRuns("foo").Delete("test-pipeline-run-success-unit-test-1", &metav1.DeleteOptions{GracePeriodSeconds:new(int64)}); err != nil {
-		t.Fatalf("Failed to delete TaskRun: %s", err)
-	}
-
-	reconciledRun.Status.SetCondition(&duckv1alpha1.Condition{
-		Type:    duckv1alpha1.ConditionSucceeded,
-		Status:  corev1.ConditionTrue,
-		Reason:  resources.ReasonSucceeded,
-		Message: "All Tasks have completed executing",
-	})
-
-	if _, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Update(reconciledRun); err != nil {
-		t.Fatalf("Error updating PipelineRun: %s", err)
-	}
-
-	informers.PipelineRun.Informer().GetIndexer().Add(reconciledRun)
-
-	if err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-success"); err != nil {
-		t.Errorf("Did not expect to see error when reconciling valid Pipeline but saw %s", err)
-	}
-
-	// Check that the PipelineRun was not changed by reconciliation
-	twiceReconciledRun, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-success", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
-	}
-
-	// This PipelineRun should still be complete and the status should reflect that
-	if twiceReconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown() {
-		t.Errorf("Expected PipelineRun status to be complete, but was %v", twiceReconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
-	}
-
-	// Verify that there is no TaskRun with the expected name.
-	if _, err:= clients.Pipeline.Pipeline().TaskRuns("foo").Get("test-pipeline-run-success-unit-test-1", metav1.GetOptions{}); err == nil {
-		t.Errorf("Found unexpected TaskRun test-pipeline-run-success-unit-test-1")
 	}
 }
 
@@ -622,4 +584,73 @@ func TestUpdateTaskRunsState(t *testing.T) {
 		t.Fatalf("Expected PipelineRun status to match TaskRun(s) status, but got a mismatch: %s", d)
 	}
 
+}
+
+func TestReconcileOnCompletedPipelineRun(t *testing.T) {
+	prs := []*v1alpha1.PipelineRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline-run-completed",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "test-pipeline",
+			},
+			ServiceAccount: "test-sa",
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			Conditions: []duckv1alpha1.Condition{{
+				Type:    duckv1alpha1.ConditionSucceeded,
+				Status:  corev1.ConditionTrue,
+				Reason:  resources.ReasonSucceeded,
+				Message: "All Tasks have completed executing",
+			}},
+		},
+	}}
+	ps := []*v1alpha1.Pipeline{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Tasks: []v1alpha1.PipelineTask{{
+				Name:    "hello-world-1",
+				TaskRef: v1alpha1.TaskRef{Name: "hello-world"},
+			}},
+		},
+	}}
+	ts := []*v1alpha1.Task{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hello-world",
+			Namespace: "foo",
+		},
+	}}
+	d := test.Data{
+		PipelineRuns:      prs,
+		Pipelines:         ps,
+		Tasks:             ts,
+	}
+
+	testAssets := test.GetPipelineRunController(d)
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-completed")
+	if err != nil {
+		t.Errorf("Did not expect to see error when reconciling completed PipelineRun but saw %s", err)
+	}
+	if len(clients.Pipeline.Actions()) != 0 {
+		t.Fatalf("Expected client to not have created a TaskRun for the completed PipelineRun, but it did")
+	}
+
+	// Check that the PipelineRun was reconciled correctly
+	reconciledRun, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-completed", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+
+	// This PipelineRun should still be complete and the status should reflect that
+	if reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown() {
+		t.Errorf("Expected PipelineRun status to be complete, but was %v", reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
+	}
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -166,6 +166,10 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	tr := original.DeepCopy()
 	tr.Status.InitializeConditions()
 
+	if isDone(&tr.Status) {
+		return nil
+	}
+
 	// Reconcile this copy of the task run and then write back any status
 	// updates regardless of whether the reconciliation errored out.
 	err = c.reconcile(ctx, tr)
@@ -490,4 +494,9 @@ func makeLabels(s *v1alpha1.TaskRun) map[string]string {
 	}
 	return labels
 
+}
+
+// isDone returns true if the TaskRun's status indicates that it is done.
+func isDone(status *v1alpha1.TaskRunStatus) bool {
+	return !status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -772,7 +772,9 @@ func TestReconcile(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, clients, _ := test.GetTaskRunController(d)
+			testAssets := test.GetTaskRunController(d)
+			c := testAssets.Controller
+			clients := testAssets.Clients
 			if err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun)); err != nil {
 				t.Errorf("expected no error. Got error %v", err)
 			}
@@ -888,7 +890,9 @@ func TestReconcile_InvalidTaskRuns(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, clients, _ := test.GetTaskRunController(d)
+			testAssets := test.GetTaskRunController(d)
+			c := testAssets.Controller
+			clients := testAssets.Clients
 			err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun))
 			// When a TaskRun is invalid and can't run, we don't want to return an error because
 			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
@@ -932,7 +936,9 @@ func TestReconcileBuildFetchError(t *testing.T) {
 		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 
-	c, _, clients, _ := test.GetTaskRunController(d)
+	testAssets := test.GetTaskRunController(d)
+	c := testAssets.Controller
+	clients := testAssets.Clients
 
 	reactor := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetVerb() == "get" && action.GetResource().Resource == "builds" {
@@ -984,7 +990,9 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 		Builds: []*buildv1alpha1.Build{build},
 	}
 
-	c, _, clients, _ := test.GetTaskRunController(d)
+	testAssets := test.GetTaskRunController(d)
+	c := testAssets.Controller
+	clients := testAssets.Clients
 
 	if err := c.Reconciler.Reconcile(context.Background(), fmt.Sprintf("%s/%s", taskRun.Namespace, taskRun.Name)); err != nil {
 		t.Fatalf("Unexpected error when Reconcile() : %v", err)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -772,7 +772,7 @@ func TestReconcile(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, clients := test.GetTaskRunController(d)
+			c, _, clients, _ := test.GetTaskRunController(d)
 			if err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun)); err != nil {
 				t.Errorf("expected no error. Got error %v", err)
 			}
@@ -888,7 +888,7 @@ func TestReconcile_InvalidTaskRuns(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			c, _, clients := test.GetTaskRunController(d)
+			c, _, clients, _ := test.GetTaskRunController(d)
 			err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun))
 			// When a TaskRun is invalid and can't run, we don't want to return an error because
 			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
@@ -932,7 +932,7 @@ func TestReconcileBuildFetchError(t *testing.T) {
 		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 
-	c, _, clients := test.GetTaskRunController(d)
+	c, _, clients, _ := test.GetTaskRunController(d)
 
 	reactor := func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		if action.GetVerb() == "get" && action.GetResource().Resource == "builds" {
@@ -984,7 +984,7 @@ func TestReconcileBuildUpdateStatus(t *testing.T) {
 		Builds: []*buildv1alpha1.Build{build},
 	}
 
-	c, _, clients := test.GetTaskRunController(d)
+	c, _, clients, _ := test.GetTaskRunController(d)
 
 	if err := c.Reconciler.Reconcile(context.Background(), fmt.Sprintf("%s/%s", taskRun.Namespace, taskRun.Name)); err != nil {
 		t.Fatalf("Unexpected error when Reconcile() : %v", err)

--- a/test/controller.go
+++ b/test/controller.go
@@ -143,7 +143,7 @@ func seedTestData(d Data) (Clients, Informers) {
 
 // GetTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
-func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Clients) {
+func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Clients, Informers) {
 	c, i := seedTestData(d)
 	observer, logs := observer.New(zap.InfoLevel)
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.Namespace)
@@ -160,12 +160,12 @@ func GetTaskRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Cli
 		i.ClusterTask,
 		i.Build,
 		i.PipelineResource,
-	), logs, c
+	), logs, c, i
 }
 
 // GetPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
-func GetPipelineRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Clients) {
+func GetPipelineRunController(d Data) (*controller.Impl, *observer.ObservedLogs, Clients, Informers) {
 	c, i := seedTestData(d)
 	observer, logs := observer.New(zap.InfoLevel)
 	return pipelinerun.NewController(
@@ -180,5 +180,5 @@ func GetPipelineRunController(d Data) (*controller.Impl, *observer.ObservedLogs,
 		i.ClusterTask,
 		i.TaskRun,
 		i.PipelineResource,
-	), logs, c
+	), logs, c, i
 }

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -96,14 +96,14 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 		}
 		return false, nil
 	}, "PipelineRunCompleted"); err != nil {
-		taskruns, secondErr := c.TaskRunClient.List(metav1.ListOptions{})
-		if secondErr != nil {
-			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", helmDeployPipelineRunName, secondErr)
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", helmDeployPipelineRunName, err)
+		taskruns, err := c.TaskRunClient.List(metav1.ListOptions{})
+		if err != nil {
+			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", helmDeployPipelineRunName, err)
 		}
 		for _, tr := range taskruns.Items {
 			CollectBuildLogs(c, tr.Name, namespace, logger)
 		}
-		t.Errorf("Error waiting for PipelineRun %s to finish: %s", helmDeployPipelineRunName, err)
 	}
 
 	logger.Info("Waiting for service to get external IP")

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -96,9 +96,9 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 		}
 		return false, nil
 	}, "PipelineRunCompleted"); err != nil {
-		taskruns, err := c.TaskRunClient.List(metav1.ListOptions{})
-		if err != nil {
-			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", helmDeployPipelineRunName, err)
+		taskruns, secondErr := c.TaskRunClient.List(metav1.ListOptions{})
+		if secondErr != nil {
+			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", helmDeployPipelineRunName, secondErr)
 		}
 		for _, tr := range taskruns.Items {
 			CollectBuildLogs(c, tr.Name, namespace, logger)

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -21,7 +21,6 @@ package test
 import (
 	"encoding/base64"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"strings"
 	"testing"
 	"time"
@@ -196,101 +195,6 @@ func TestPipelineRun(t *testing.T) {
 			}
 			logger.Infof("Successfully finished test %q", td.name)
 		})
-	}
-}
-
-func TestPipelineRunStaysFinished(t *testing.T) {
-	logger := getContextLogger(t.Name())
-	client, namespace := setup(t, logger)
-	index := 0
-
-	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, client, namespace) }, logger)
-	defer tearDown(t, logger, client, namespace)
-
-	logger.Infof("Setting up test resources for TestPipelineRunStaysFinished test in namespace %s", namespace)
-	if _, err := client.KubeClient.Kube.CoreV1().Secrets(namespace).Create(getPipelineRunSecret(index, namespace)); err != nil {
-		t.Fatalf("Failed to create secret `%s`: %s", getName(hwSecret, index), err)
-	}
-
-	if _, err := client.KubeClient.Kube.CoreV1().ServiceAccounts(namespace).Create(getPipelineRunServiceAccount(index, namespace)); err != nil {
-		t.Fatalf("Failed to create SA `%s`: %s", getName(hwSA, index), err)
-	}
-
-	if _, err := client.TaskClient.Create(&v1alpha1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      getName(hwTaskName, index),
-		},
-		Spec: v1alpha1.TaskSpec{
-			// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
-			Steps: []corev1.Container{{
-				Name:  "say-hello",
-				Image: "ubuntu",
-				// Private docker image for Build CRD testing
-				Command: []string{"/bin/bash"},
-				Args:    []string{"-c", "echo hello"},
-			}},
-		},
-	}); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", getName(hwTaskName, index), err)
-	}
-
-	if _, err := client.PipelineClient.Create(getHelloWorldPipelineWithSingularTask(index, namespace)); err != nil {
-		t.Fatalf("Failed to create Pipeline `%s`: %s", getName(hwPipelineName, index), err)
-	}
-
-	prName := fmt.Sprintf("%s%d", hwPipelineRunName, index)
-	if _, err := client.PipelineRunClient.Create(getHelloWorldPipelineRun(index, namespace)); err != nil {
-		t.Fatalf("Failed to create PipelineRun `%s`: %s", prName, err)
-	}
-
-	logger.Infof("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(client, prName, pipelineRunTimeout, func(tr *v1alpha1.PipelineRun) (bool, error) {
-		condition := tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
-		if condition != nil {
-			if condition.IsTrue() {
-				return true, nil
-			} else if condition.IsFalse() {
-				return true, fmt.Errorf("Pipeline run %s has failed with status %v", prName, condition.Status)
-			}
-		}
-		return false, nil
-	}, "PipelineRunSuccess"); err != nil {
-		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
-	}
-
-	taskRunName := strings.Join([]string{prName, hwPipelineTaskName1}, "-")
-
-	logger.Infof("Deleting TaskRun and waiting for reconciliation")
-	if err := client.TaskRunClient.Delete(taskRunName, &metav1.DeleteOptions{}); err != nil {
-		t.Fatalf("Could not delete TaskRun %s: %s", taskRunName, err)
-	}
-
-	// TODO: I'm dead sure there's a better way to wait 30 seconds before checking stuff than wrapping it in a Poll, but...I don't know it.
-	// Verify that the PipelineRun doesn't leave the completed state
-	if err := wait.Poll(30 * time.Second, 2 * time.Minute, func() (bool, error) {
-		r, err := client.PipelineRunClient.Get(prName, metav1.GetOptions{})
-		if err != nil {
-			return true, err
-		}
-
-		c := r.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
-		if c != nil {
-			if c.IsUnknown() {
-				return true, fmt.Errorf("PipelineRun %s has restarted when it should have stayed completed", prName)
-			} else {
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		t.Fatalf("Error: %s", err)
-	}
-
-	// Verify that there is no TaskRun with the expected name.
-	_, err:= client.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
-	if err == nil {
-		t.Fatalf("Found unexpected TaskRun %s", taskRunName)
 	}
 }
 


### PR DESCRIPTION
Check whether we're "done" before proceeding further into
reconciliation, so that we won't just keep reconciling forever and
potentially resuming if, for example, a TaskRun the PipelineRun
references is deleted.

Also, this is basically how `Build`'s reconciler works, so...yeah, I derived heavily from there. =)

Fixes: #299