### PR TITLE
Remove ServiceAccountName from Task

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -42,9 +42,6 @@ type TaskSpec struct {
 	// steps of the build.
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
-	// The name of the service account as which to run this build.
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
-
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
@@ -147,11 +144,10 @@ type TaskList struct {
 
 func (ts *TaskSpec) GetBuildSpec() *buildv1alpha1.BuildSpec {
 	return &buildv1alpha1.BuildSpec{
-		Steps:              ts.Steps,
-		Volumes:            ts.Volumes,
-		ServiceAccountName: ts.ServiceAccountName,
-		NodeSelector:       ts.NodeSelector,
-		Timeout:            ts.Timeout,
-		Affinity:           ts.Affinity,
+		Steps:        ts.Steps,
+		Volumes:      ts.Volumes,
+		NodeSelector: ts.NodeSelector,
+		Timeout:      ts.Timeout,
+		Affinity:     ts.Affinity,
 	}
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -416,7 +416,12 @@ func (c *Reconciler) createBuild(ctx context.Context, tr *v1alpha1.TaskRun, ts *
 // be the entrypoint redirector binary. This function assumes that it receives
 // its own copy of the BuildSpec and modifies it freely
 func CreateRedirectedBuild(ctx context.Context, bs *buildv1alpha1.BuildSpec, pvcName string, tr *v1alpha1.TaskRun) (*buildv1alpha1.Build, error) {
-	bs.ServiceAccountName = tr.Spec.ServiceAccount
+	// Pass service account name from taskrun to build
+	// if task specifies service account name override with taskrun SA
+	if tr.Spec.ServiceAccount != "" {
+		bs.ServiceAccountName = tr.Spec.ServiceAccount
+	}
+
 	// RedirectSteps the entrypoint in each container so that we can use our custom
 	// entrypoint which copies logs to the volume
 	err := entrypoint.RedirectSteps(bs.Steps)
@@ -449,10 +454,6 @@ func CreateRedirectedBuild(ctx context.Context, bs *buildv1alpha1.BuildSpec, pvc
 			},
 		},
 	})
-
-	// Pass service account name from taskrun to build
-	// if task specifies service account name override with taskrun SA
-	b.Spec.ServiceAccountName = tr.Spec.ServiceAccount
 
 	return b, nil
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -417,10 +417,7 @@ func (c *Reconciler) createBuild(ctx context.Context, tr *v1alpha1.TaskRun, ts *
 // its own copy of the BuildSpec and modifies it freely
 func CreateRedirectedBuild(ctx context.Context, bs *buildv1alpha1.BuildSpec, pvcName string, tr *v1alpha1.TaskRun) (*buildv1alpha1.Build, error) {
 	// Pass service account name from taskrun to build
-	// if task specifies service account name override with taskrun SA
-	if tr.Spec.ServiceAccount != "" {
-		bs.ServiceAccountName = tr.Spec.ServiceAccount
-	}
+	bs.ServiceAccountName = tr.Spec.ServiceAccount
 
 	// RedirectSteps the entrypoint in each container so that we can use our custom
 	// entrypoint which copies logs to the volume

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -140,7 +140,6 @@ var saTask = &v1alpha1.Task{
 		Namespace: "foo",
 	},
 	Spec: v1alpha1.TaskSpec{
-		ServiceAccountName: "task-test-sa",
 		Steps: []corev1.Container{{
 			Name:    "sa-step",
 			Image:   "foo",
@@ -501,32 +500,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "task-serviceaccount",
-		taskRun: taskruns[7],
-		wantedBuildSpec: buildv1alpha1.BuildSpec{
-			ServiceAccountName: "task-test-sa",
-			Steps: []corev1.Container{
-				entrypointCopyStep,
-				{
-					Name:    "sa-step",
-					Image:   "foo",
-					Command: []string{entrypointLocation},
-					Args:    []string{},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "ENTRYPOINT_OPTIONS",
-							Value: `{"args":["/mycmd"],"process_log":"/tools/process-log.txt","marker_file":"/tools/marker-file.txt"}`,
-						},
-					},
-					VolumeMounts: []corev1.VolumeMount{toolsMount},
-				},
-			},
-			Volumes: []corev1.Volume{
-				getToolsVolume(taskruns[7].Name),
-			},
-		},
-	}, {
-		name:    "both-serviceaccount",
+		name:    "serviceaccount",
 		taskRun: taskruns[1],
 		wantedBuildSpec: buildv1alpha1.BuildSpec{
 			ServiceAccountName: "test-sa",

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -140,6 +140,7 @@ var saTask = &v1alpha1.Task{
 		Namespace: "foo",
 	},
 	Spec: v1alpha1.TaskSpec{
+		ServiceAccountName: "task-test-sa",
 		Steps: []corev1.Container{{
 			Name:    "sa-step",
 			Image:   "foo",
@@ -453,6 +454,17 @@ func TestReconcile(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun-with-task-sa-run-success",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{
+				Name:       saTask.Name,
+				APIVersion: "a1",
+			},
+		},
 	}}
 
 	d := test.Data{
@@ -489,7 +501,32 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	}, {
-		name:    "serviceaccount",
+		name:    "task-serviceaccount",
+		taskRun: taskruns[7],
+		wantedBuildSpec: buildv1alpha1.BuildSpec{
+			ServiceAccountName: "task-test-sa",
+			Steps: []corev1.Container{
+				entrypointCopyStep,
+				{
+					Name:    "sa-step",
+					Image:   "foo",
+					Command: []string{entrypointLocation},
+					Args:    []string{},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ENTRYPOINT_OPTIONS",
+							Value: `{"args":["/mycmd"],"process_log":"/tools/process-log.txt","marker_file":"/tools/marker-file.txt"}`,
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{toolsMount},
+				},
+			},
+			Volumes: []corev1.Volume{
+				getToolsVolume(taskruns[7].Name),
+			},
+		},
+	}, {
+		name:    "both-serviceaccount",
 		taskRun: taskruns[1],
 		wantedBuildSpec: buildv1alpha1.BuildSpec{
 			ServiceAccountName: "test-sa",


### PR DESCRIPTION
<del>If a Task specify a `ServiceAccountName` but the `TaskRun` referencing
it doesn't, the resulting `BuildSpec` will contain *no*
`ServiceAccountName` instead of having the `Task` one.</del>

> Actually I think ServiceAccount should not be in Task. ServiceAccount is a runtime concept that should be coming from TaskRun, not Task. Task only has it because it was copied from BuildSpec, but I don't we should use it

Closes #305 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>