### PR TITLE
Add a TaskRun and PipelineRun status tests and add test builders 💃

### DIFF
--- a/test/builder.go
+++ b/test/builder.go
@@ -1,0 +1,184 @@
+package test
+
+import (
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Task(name, namespace string, ops ...func(*v1alpha1.Task)) *v1alpha1.Task {
+	t := &v1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	for _, op := range ops {
+		op(t)
+	}
+
+	return t
+}
+
+func TaskSpec(ops ...func(*v1alpha1.TaskSpec)) func(*v1alpha1.Task) {
+	return func(t *v1alpha1.Task) {
+		spec := &t.Spec
+		for _, op := range ops {
+			op(spec)
+		}
+		t.Spec = *spec
+	}
+}
+
+func Step(name, image string, ops ...func(*corev1.Container)) func(*v1alpha1.TaskSpec) {
+	return func(spec *v1alpha1.TaskSpec) {
+		if spec.Steps == nil {
+			spec.Steps = []corev1.Container{}
+		}
+		step := &corev1.Container{
+			Name:  name,
+			Image: image,
+		}
+		for _, op := range ops {
+			op(step)
+		}
+		spec.Steps = append(spec.Steps, *step)
+	}
+}
+
+func Command(args ...string) func(*corev1.Container) {
+	return func(container *corev1.Container) {
+		container.Command = args
+	}
+}
+
+func TaskRun(name, namespace string, ops ...func(*v1alpha1.TaskRun)) *v1alpha1.TaskRun {
+	tr := &v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			Trigger: v1alpha1.TaskTrigger{
+				TriggerRef: v1alpha1.TaskTriggerRef{
+					Type: v1alpha1.TaskTriggerTypeManual,
+				},
+			},
+		},
+	}
+
+	for _, op := range ops {
+		op(tr)
+	}
+
+	return tr
+}
+
+func TaskRunSpec(name string, ops ...func(*v1alpha1.TaskRunSpec)) func(*v1alpha1.TaskRun) {
+	return func(tr *v1alpha1.TaskRun) {
+		spec := &tr.Spec
+		spec.TaskRef = &v1alpha1.TaskRef{
+			Name: name,
+		}
+		for _, op := range ops {
+			op(spec)
+		}
+		tr.Spec = *spec
+	}
+}
+
+func TaskTrigger(name string, triggerType v1alpha1.TaskTriggerType) func(*v1alpha1.TaskRunSpec) {
+	return func(trs *v1alpha1.TaskRunSpec) {
+		trs.Trigger = v1alpha1.TaskTrigger{
+			TriggerRef: v1alpha1.TaskTriggerRef{
+				Name: name,
+				Type: triggerType,
+			},
+		}
+	}
+}
+
+func TaskRunServiceAccount(sa string) func(*v1alpha1.TaskRunSpec) {
+	return func(trs *v1alpha1.TaskRunSpec) {
+		trs.ServiceAccount = sa
+	}
+}
+
+func Pipeline(name, namespace string, ops ...func(*v1alpha1.Pipeline)) *v1alpha1.Pipeline {
+	p := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	for _, op := range ops {
+		op(p)
+	}
+
+	return p
+}
+
+func PipelineSpec(ops ...func(*v1alpha1.PipelineSpec)) func(*v1alpha1.Pipeline) {
+	return func(p *v1alpha1.Pipeline) {
+		ps := &p.Spec
+
+		for _, op := range ops {
+			op(ps)
+		}
+
+		p.Spec = *ps
+	}
+}
+
+func PipelineTask(name, taskName string) func(*v1alpha1.PipelineSpec) {
+	return func(ps *v1alpha1.PipelineSpec) {
+		ps.Tasks = append(ps.Tasks, v1alpha1.PipelineTask{
+			Name: name,
+			TaskRef: v1alpha1.TaskRef{
+				Name: taskName,
+			},
+		})
+	}
+}
+
+func PipelineRun(name, namespace string, ops ...func(*v1alpha1.PipelineRun)) *v1alpha1.PipelineRun {
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineTriggerRef: v1alpha1.PipelineTriggerRef{
+				Type: v1alpha1.PipelineTriggerTypeManual,
+			},
+		},
+	}
+
+	for _, op := range ops {
+		op(pr)
+	}
+
+	return pr
+}
+
+func PipelineRunSpec(name string, ops ...func(*v1alpha1.PipelineRunSpec)) func(*v1alpha1.PipelineRun) {
+	return func(pr *v1alpha1.PipelineRun) {
+		prs := &pr.Spec
+
+		prs.PipelineRef.Name = name
+
+		for _, op := range ops {
+			op(prs)
+		}
+
+		pr.Spec = *prs
+	}
+}
+
+func PipelineRunServiceAccount(sa string) func(*v1alpha1.PipelineRunSpec) {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.ServiceAccount = sa
+	}
+}

--- a/test/crd.go
+++ b/test/crd.go
@@ -84,38 +84,13 @@ func getHelloWorldValidationPod(namespace, volumeClaimName string) *corev1.Pod {
 }
 
 func getHelloWorldTask(namespace string, args []string) *v1alpha1.Task {
-	return &v1alpha1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      hwTaskName,
-		},
-		Spec: v1alpha1.TaskSpec{
-			Steps: []corev1.Container{{
-				Name:    hwContainerName,
-				Image:   "busybox",
-				Command: args,
-			}},
-		},
-	}
+	return Task(hwTaskName, namespace,
+		TaskSpec(Step(hwContainerName, "busybox", Command(args...))),
+	)
 }
 
 func getHelloWorldTaskRun(namespace string) *v1alpha1.TaskRun {
-	return &v1alpha1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      hwTaskRunName,
-		},
-		Spec: v1alpha1.TaskRunSpec{
-			TaskRef: &v1alpha1.TaskRef{
-				Name: hwTaskName,
-			},
-			Trigger: v1alpha1.TaskTrigger{
-				TriggerRef: v1alpha1.TaskTriggerRef{
-					Type: v1alpha1.TaskTriggerTypeManual,
-				},
-			},
-		},
-	}
+	return TaskRun(hwTaskRunName, namespace, TaskRunSpec(hwTaskName))
 }
 
 func getBuildOutputFromVolume(logger *logging.BaseLogger, c *clients, namespace, testStr string) (string, error) {

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -27,9 +27,10 @@ import (
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-// TestTaskRunStatus is an integration test that will verify a very simple "hello world" TaskRun
-// failure execution lead to the correct TaskRun status.
-func TestTaskRunStatus(t *testing.T) {
+// TestTaskRunPipelineRunStatus is an integration test that will
+// verify a very simple "hello world" TaskRun and PipelineRun failure
+// execution lead to the correct TaskRun status.
+func TestTaskRunPipelineRunStatus(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 
@@ -63,31 +64,12 @@ func TestTaskRunStatus(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", hwTaskRunName, err)
 	}
 
-}
-
-// TestPipelineRunStatus is an integration test that will verify a very simple "hello world" TaskRun
-// failure execution lead to the correct PipelineRun status.
-func TestPipelineRunStatus(t *testing.T) {
-	logger := logging.GetContextLogger(t.Name())
-	c, namespace := setup(t, logger)
-
-	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
-	defer tearDown(t, logger, c, namespace)
-
-	logger.Infof("Creating Task and TaskRun in namespace %s", namespace)
-	task := Task("banana", namespace, TaskSpec(
-		Step("foo", "busybox", Command("ls", "-la")),
-	))
-	if _, err := c.TaskClient.Create(task); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", hwTaskName, err)
-	}
 	pipeline := Pipeline("tomatoes", namespace,
 		PipelineSpec(PipelineTask("foo", "banana")),
 	)
 	pipelineRun := PipelineRun("pear", namespace,
 		PipelineRunSpec("tomatoes", PipelineRunServiceAccount("inexistent")),
 	)
-
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
 	}
@@ -109,5 +91,4 @@ func TestPipelineRunStatus(t *testing.T) {
 	}, "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", hwTaskRunName, err)
 	}
-
 }

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -1,0 +1,113 @@
+// +build e2e
+
+/*
+Copyright 2018 Knative Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	knativetest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// TestTaskRunStatus is an integration test that will verify a very simple "hello world" TaskRun
+// failure execution lead to the correct TaskRun status.
+func TestTaskRunStatus(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	c, namespace := setup(t, logger)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
+
+	logger.Infof("Creating Task and TaskRun in namespace %s", namespace)
+	task := Task("banana", namespace, TaskSpec(
+		Step("foo", "busybox", Command("ls", "-la")),
+	))
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", hwTaskName, err)
+	}
+	taskRun := TaskRun("apple", namespace, TaskRunSpec("banana", TaskRunServiceAccount("inexistent")))
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", hwTaskRunName, err)
+	}
+
+	logger.Infof("Waiting for TaskRun %s in namespace %s to fail", hwTaskRunName, namespace)
+	if err := WaitForTaskRunState(c, "apple", func(tr *v1alpha1.TaskRun) (bool, error) {
+		c := tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("task run %s succeeded!", "apple")
+			} else if c.Status == corev1.ConditionFalse {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "BuildValidationFailed"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", hwTaskRunName, err)
+	}
+
+}
+
+// TestPipelineRunStatus is an integration test that will verify a very simple "hello world" TaskRun
+// failure execution lead to the correct PipelineRun status.
+func TestPipelineRunStatus(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	c, namespace := setup(t, logger)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
+
+	logger.Infof("Creating Task and TaskRun in namespace %s", namespace)
+	task := Task("banana", namespace, TaskSpec(
+		Step("foo", "busybox", Command("ls", "-la")),
+	))
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", hwTaskName, err)
+	}
+	pipeline := Pipeline("tomatoes", namespace,
+		PipelineSpec(PipelineTask("foo", "banana")),
+	)
+	pipelineRun := PipelineRun("pear", namespace,
+		PipelineRunSpec("tomatoes", PipelineRunServiceAccount("inexistent")),
+	)
+
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+	}
+
+	logger.Infof("Waiting for PipelineRun %s in namespace %s to fail", hwTaskRunName, namespace)
+	if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, func(tr *v1alpha1.PipelineRun) (bool, error) {
+		c := tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("task run %s succeeded!", "apple")
+			} else if c.Status == corev1.ConditionFalse {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "BuildValidationFailed"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", hwTaskRunName, err)
+	}
+
+}


### PR DESCRIPTION
- This is a follow-up of #285 to show the fix (aka this new
  `status_test.go` tests fails if you revert that commit)
- This also adds a start of test *builders* to ease the creation of
  test objects.

A quick note of the builders : while writing those tests (and other unit tests for other PRs) I found we may tend to write too much code to create those test object. I'm quoting [myself](https://vincent.demeester.fr/posts/2017-01-01-go-testing-functionnal-builders/) (sorry :sweat_smile:)

> One of the most important characteristic of a unit test (and any type of test really) is readability. This means it should be easy to read but most importantly it should clearly show the intent of the test. The setup (and cleanup) of the tests should be as small as possible to avoid the noise.

Those builders are here to help (and if you think they don't, then we don't need them :wink:) : 
- it makes it easier to create object (less noise)
- the intent is clearer — by providing sane default in those, it *should* make it easier to see what are the main characteristics of those object we're using to test
- they are extensible and re-usable easily (thanks to functions :stuck_out_tongue_closed_eyes:). You can even use inline functions for specific needs.

```go
taskRun := TaskRun("apple", namespace, TaskRunSpec("banana"), func(t *v1alpha1.TaskRun) {
	Status: v1alpha.TaskRunStatus {
		PodName: "foo",
		// […]
	}
})
```

As of now, they live in the `test` package *and* are only used on the new test. If we think they are useful, I'll update the other tests and add more useful functions :wink: 

/cc @bobcatfish @shashwathi @pivotal-nader-ziada 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>