### PR TITLE
Format markdown

### DIFF
--- a/docs/Concepts.md
+++ b/docs/Concepts.md
@@ -128,8 +128,9 @@ the `image`'s value in a configmap named
 
 ### Cluster Task
 
-Similar to `Task` but with a cluster-wide scope. Cluster Tasks are available in 
-all namespaces, typically used to conveniently provide commonly used tasks to users.
+Similar to `Task` but with a cluster-wide scope. Cluster Tasks are available in
+all namespaces, typically used to conveniently provide commonly used tasks to
+users.
 
 ### Pipeline
 

--- a/docs/using.md
+++ b/docs/using.md
@@ -143,8 +143,8 @@ ${inputs.params.NAME}
 
 Similar to Task, but with a cluster scope.
 
-In case of using a ClusterTask, the `TaskRef` kind should be added. The default kind is Task 
-which represents a namespaced Task
+In case of using a ClusterTask, the `TaskRef` kind should be added. The default
+kind is Task which represents a namespaced Task
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -154,12 +154,11 @@ metadata:
   namespace: default
 spec:
   tasks:
-  - name: build-skaffold-web
-    taskRef:
-      name: build-push
-      kind: ClusterTask
-    params:
-      ....
+    - name: build-skaffold-web
+      taskRef:
+        name: build-push
+        kind: ClusterTask
+      params: ....
 ```
 
 ## Running a Pipeline


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`