### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -626,9 +626,9 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 		},
 	}}
 	d := test.Data{
-		PipelineRuns:      prs,
-		Pipelines:         ps,
-		Tasks:             ts,
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
 	}
 
 	testAssets := test.GetPipelineRunController(d)

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/knative/build/pkg/apis/build/v1alpha1"

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -1255,17 +1255,17 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 		},
 	}
 	taskSt := &duckv1alpha1.Condition{
-			Type:    duckv1alpha1.ConditionSucceeded,
-			Status:  corev1.ConditionTrue,
-			Reason:  "Build succeeded",
-			Message: "Build succeeded",
+		Type:    duckv1alpha1.ConditionSucceeded,
+		Status:  corev1.ConditionTrue,
+		Reason:  "Build succeeded",
+		Message: "Build succeeded",
 	}
 	taskRun.Status.SetCondition(taskSt)
 	d := test.Data{
 		TaskRuns: []*v1alpha1.TaskRun{
 			taskRun,
 		},
-		Tasks:  []*v1alpha1.Task{simpleTask},
+		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 
 	testAssets := test.GetTaskRunController(d)

--- a/test/controller.go
+++ b/test/controller.go
@@ -77,9 +77,9 @@ type Informers struct {
 // TestAssets holds references to the controller, logs, clients, and informers.
 type TestAssets struct {
 	Controller *controller.Impl
-	Logs *observer.ObservedLogs
-	Clients Clients
-	Informers Informers
+	Logs       *observer.ObservedLogs
+	Clients    Clients
+	Informers  Informers
 }
 
 func seedTestData(d Data) (Clients, Informers) {
@@ -151,7 +151,7 @@ func seedTestData(d Data) (Clients, Informers) {
 
 // GetTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
-func GetTaskRunController(d Data) (TestAssets) {
+func GetTaskRunController(d Data) TestAssets {
 	c, i := seedTestData(d)
 	observer, logs := observer.New(zap.InfoLevel)
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.Namespace)
@@ -170,15 +170,15 @@ func GetTaskRunController(d Data) (TestAssets) {
 			i.Build,
 			i.PipelineResource,
 		),
-		Logs: logs,
-		Clients: c,
+		Logs:      logs,
+		Clients:   c,
 		Informers: i,
 	}
 }
 
 // GetPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
-func GetPipelineRunController(d Data) (TestAssets) {
+func GetPipelineRunController(d Data) TestAssets {
 	c, i := seedTestData(d)
 	observer, logs := observer.New(zap.InfoLevel)
 	return TestAssets{
@@ -195,8 +195,8 @@ func GetPipelineRunController(d Data) (TestAssets) {
 			i.TaskRun,
 			i.PipelineResource,
 		),
-		Logs: logs,
-		Clients: c,
+		Logs:      logs,
+		Clients:   c,
 		Informers: i,
 	}
 }


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
