### PR TITLE
Format markdown

### DIFF
--- a/hack/release.md
+++ b/hack/release.md
@@ -17,9 +17,9 @@ release.
 - `--tag-release`, `--notag-release` Tag (or not) the generated images with
   either `vYYYYMMDD-<commit_short_hash>` (for nightly releases) or `vX.Y.Z` for
   versioned releases. _For versioned releases, a tag is always added._
-- `--release-gcs` Defines the GCS bucket where the manifests will be stored.
-  By default, this is `knative-nightly/build-pipeline`. This flag is ignored
-  if the release is not being published.
+- `--release-gcs` Defines the GCS bucket where the manifests will be stored. By
+  default, this is `knative-nightly/build-pipeline`. This flag is ignored if the
+  release is not being published.
 - `--release-gcr` Defines the GCR where the images will be stored. By default,
   this is `gcr.io/knative-nightly`. This flag is ignored if the release is not
   being published.

--- a/test/README.md
+++ b/test/README.md
@@ -183,8 +183,8 @@ go test -v -tags=e2e -count=1 ./test -run ^TestTaskRun$
 
 ### Running YAML tests
 
-To run the YAML e2e tests, from the examples folder, you need to have a valid cluster 
-and run the following command:
+To run the YAML e2e tests, from the examples folder, you need to have a valid
+cluster and run the following command:
 
 ```bash
 ./test/e2e-yaml-tests.sh


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`