### PR TITLE
Small refactoring in `test` to declare test Helpers

### DIFF
--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//CollectBuildLogs will get the build logs for a task run
+// CollectBuildLogs will get the build logs for a task run
 func CollectBuildLogs(c *clients, podName, namespace string, logger *logging.BaseLogger) {
 	logs, err := getInitContainerLogsFromPod(c.KubeClient.Kube, podName, namespace)
 	if err != nil {

--- a/test/clients.go
+++ b/test/clients.go
@@ -16,7 +16,7 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
+	"testing"
 
 	"github.com/knative/build-pipeline/pkg/client/clientset/versioned"
 	"github.com/knative/build-pipeline/pkg/client/clientset/versioned/typed/pipeline/v1alpha1"
@@ -37,28 +37,29 @@ type clients struct {
 // newClients instantiates and returns several clientsets required for making requests to the
 // Pipeline cluster specified by the combination of clusterName and configPath. Clients can
 // make requests within namespace.
-func newClients(configPath, clusterName, namespace string) (*clients, error) {
+func newClients(t *testing.T, configPath, clusterName, namespace string) *clients {
+	t.Helper()
 	var err error
 	c := &clients{}
 
 	c.KubeClient, err = knativetest.NewKubeClient(configPath, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kubeclient from config file at %s: %s", configPath, err)
+		t.Fatalf("failed to create kubeclient from config file at %s: %s", configPath, err)
 	}
 
 	cfg, err := knativetest.BuildClientConfig(configPath, clusterName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create configuration obj from %s for cluster %s: %s", configPath, clusterName, err)
+		t.Fatalf("failed to create configuration obj from %s for cluster %s: %s", configPath, clusterName, err)
 	}
 
 	cs, err := versioned.NewForConfig(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create pipeline clientset from config file at %s: %s", configPath, err)
+		t.Fatalf("failed to create pipeline clientset from config file at %s: %s", configPath, err)
 	}
 	c.PipelineClient = cs.PipelineV1alpha1().Pipelines(namespace)
 	c.TaskClient = cs.PipelineV1alpha1().Tasks(namespace)
 	c.TaskRunClient = cs.PipelineV1alpha1().TaskRuns(namespace)
 	c.PipelineRunClient = cs.PipelineV1alpha1().PipelineRuns(namespace)
 	c.PipelineResourceClient = cs.PipelineV1alpha1().PipelineResources(namespace)
-	return c, nil
+	return c
 }

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -51,13 +51,10 @@ func getContextLogger(n string) *logging.BaseLogger {
 }
 
 func setup(t *testing.T, logger *logging.BaseLogger) (*clients, string) {
+	t.Helper()
 	namespace := AppendRandomString("arendelle")
 
-	c, err := newClients(knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
-	if err != nil {
-		t.Fatalf("Couldn't initialize clients: %v", err)
-	}
-
+	c := newClients(t, knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
 	createNamespace(namespace, logger, c.KubeClient)
 
 	return c, namespace
@@ -74,6 +71,7 @@ func header(logger *logging.BaseLogger, text string) {
 }
 
 func tearDown(t *testing.T, logger *logging.BaseLogger, cs *clients, namespace string) {
+	t.Helper()
 	if cs.KubeClient == nil {
 		return
 	}

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -62,10 +62,7 @@ func TestTaskRun(t *testing.T) {
 
 	// The volume created with the results will have the same name as the TaskRun
 	logger.Infof("Verifying TaskRun %s output in volume %s", hwTaskRunName, hwTaskRunName)
-	output, err := getBuildOutputFromVolume(logger, c, namespace, taskOutput)
-	if err != nil {
-		t.Fatalf("Unable to get build output from volume %s: %s", hwTaskRunName, err)
-	}
+	output := getBuildOutputFromVolume(t, logger, c, namespace, taskOutput)
 	if !strings.Contains(output, taskOutput) {
 		t.Fatalf("Expected output %s from pod %s but got %s", buildOutput, hwValidationPodName, output)
 	}


### PR DESCRIPTION
`t.Helper` allows the errors repor to point to the caller instead of
the current `t.Fatal`/`t.Error`… So it makes it easier to see which
test fail.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>