### PR TITLE
Format markdown

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -313,7 +313,6 @@ spec:
       - name: workspace
         resourceRef:
           name: go-example-git
-...
 ```
 
 Where `serviceAccount: test-build-robot-git-ssh` references to the following


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`