### PR TITLE
Unexport methods which were only exported to avoid dependency cycle

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -22,26 +22,23 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/knative/build-pipeline/pkg/apis/pipeline"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	informers "github.com/knative/build-pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
+	listers "github.com/knative/build-pipeline/pkg/client/listers/pipeline/v1alpha1"
 	"github.com/knative/build-pipeline/pkg/reconciler"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/controller"
-
 	"github.com/knative/pkg/tracker"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-
-	informers "github.com/knative/build-pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
-	listers "github.com/knative/build-pipeline/pkg/client/listers/pipeline/v1alpha1"
 )
 
 const (
@@ -241,13 +238,13 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 
 	reconciler.EmitEvent(c.Recorder, before, after, pr)
 
-	UpdateTaskRunsStatus(pr, pipelineState)
+	updateTaskRunsStatus(pr, pipelineState)
 
 	c.Logger.Infof("PipelineRun %s status is being set to %s", pr.Name, pr.Status)
 	return nil
 }
 
-func UpdateTaskRunsStatus(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask) {
+func updateTaskRunsStatus(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask) {
 	for _, rprt := range pipelineState {
 		if rprt.TaskRun != nil {
 			pr.Status.TaskRuns[rprt.TaskRun.Name] = rprt.TaskRun.Status


### PR DESCRIPTION
Previously, `taskrun_test.go` was in the `taskrun_test` package to avoid a circular dependency since `test` depended on `taskrun`, to support `GetTaskRunController`, which was only used in `taskrun_test.go`.

This resulted in a bunch of consts and funcs to be exported so that they could be referenced from the `taskrun_test` package.

Instead, this change moves `GetTaskRunController` into the only place it's used, unexported as `getTaskRunController`, and since the cycle is broken, move `taskrun_test.go` to the `taskrun` package. This enables all those consts/funcs to be unexported. 🎉 

Likewise for the `pipelinerun_test`, for all the same reasons.

This refactor does require one method from the `test` package to _become_ exported, `test.SeedTestData`, but I think that's a lot cleaner than exporting things from our live code packages just to enable tests.

No functional changes are expected in this change.

![l0iykosxlecvejozm](https://user-images.githubusercontent.com/210737/50033090-f9309000-ffab-11e8-9b3c-bd14744b6b97.gif)

/assign @bobcatfish 