### PR TITLE
Migrate more unit test using builder 🏗

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -100,13 +100,13 @@ var (
 	))
 
 	gitResource = tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeGit, tb.PipelineSpecParam("URL", "https://foo.git"),
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
 	anotherGitResource = tb.PipelineResource("another-git-resource", "foo", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeGit, tb.PipelineSpecParam("URL", "https://foobar.git"),
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foobar.git"),
 	))
 	imageResource = tb.PipelineResource("image-resource", "foo", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeImage, tb.PipelineSpecParam("URL", "gcr.io/kristoff/sven"),
+		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
 	))
 )
 
@@ -176,28 +176,28 @@ func getTaskRunController(d test.Data) test.TestAssets {
 
 func TestReconcile(t *testing.T) {
 	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRefAPIVersion("a1"),
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 	))
 	taskRunWithSaSuccess := tb.TaskRun("test-taskrun-with-sa-run-success", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef(saTask.Name), tb.TaskRefAPIVersion("a1"), tb.TaskRunServiceAccount("test-sa"),
+		tb.TaskRunTaskRef(saTask.Name, tb.TaskRefAPIVersion("a1")), tb.TaskRunServiceAccount("test-sa"),
 	))
 	taskRunTemplating := tb.TaskRun("test-taskrun-templating", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef(templatedTask.Name), tb.TaskRefAPIVersion("a1"),
+		tb.TaskRunTaskRef(templatedTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
-			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef(gitResource.Name, "a1")),
+			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef(gitResource.Name)),
 		),
-		tb.TaskRunOutputs(tb.TaskRunOutputsResource("myimage", tb.ResourceBindingRef("image-resource", "a1"))),
+		tb.TaskRunOutputs(tb.TaskRunOutputsResource("myimage", tb.ResourceBindingRef("image-resource"))),
 	))
 	taskRunOverrivdesDefaultTemplating := tb.TaskRun("test-taskrun-overrides-default-templating", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef(defaultTemplatedTask.Name), tb.TaskRefAPIVersion("a1"),
+		tb.TaskRunTaskRef(defaultTemplatedTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
 			tb.TaskRunInputsResource(gitResource.Name),
 		),
 	))
 	taskRunDefaultTemplating := tb.TaskRun("test-taskrun-default-templating", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef(defaultTemplatedTask.Name), tb.TaskRefAPIVersion("a1"),
+		tb.TaskRunTaskRef(defaultTemplatedTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunInputs(
 			tb.TaskRunInputsResource(gitResource.Name),
 		),
@@ -224,7 +224,7 @@ func TestReconcile(t *testing.T) {
 	taskRunWithTaskSpec := tb.TaskRun("test-taskrun-with-taskSpec", "foo", tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
-			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef(gitResource.Name, "a1")),
+			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef(gitResource.Name)),
 		),
 		tb.TaskRunTaskSpec(
 			tb.TaskInputs(

--- a/pkg/reconciler/v1alpha1/taskrun/validate_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/validate_test.go
@@ -6,60 +6,38 @@ import (
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
+	tb "github.com/knative/build-pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var validBuildSteps = []corev1.Container{{
-	Name:    "mystep",
-	Image:   "myimage",
-	Command: []string{"mycmd"},
-}}
+var (
+	validBuildSteps = []corev1.Container{{
+		Name:    "mystep",
+		Image:   "myimage",
+		Command: []string{"mycmd"},
+	}}
+	validBuildStepFn = tb.Step("mystep", "myimage", tb.Command("mycmd"))
+)
 
 func TestValidateResolvedTaskResources_ValidResources(t *testing.T) {
-	rtr := &resources.ResolvedTaskResources{
-		TaskSpec: &v1alpha1.TaskSpec{
-			Steps: validBuildSteps,
-			Inputs: &v1alpha1.Inputs{
-				Resources: []v1alpha1.TaskResource{{
-					Name: "resource-to-build",
-					Type: v1alpha1.PipelineResourceTypeGit,
-				}},
-			},
-		},
-		Inputs: map[string]*v1alpha1.PipelineResource{
-			"resource-to-build": {
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "example-resource",
-					Namespace: "foo",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeGit,
-					Params: []v1alpha1.Param{{
-						Name:  "foo",
-						Value: "bar",
-					}},
-				},
-			}},
-	}
+	rtr := tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+		validBuildStepFn,
+		tb.TaskInputs(tb.InputsResource("resource-to-build", v1alpha1.PipelineResourceTypeGit)),
+	), tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource", "foo",
+		tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
+			tb.PipelineResourceSpecParam("foo", "bar"),
+		)),
+	))
 	if err := taskrun.ValidateResolvedTaskResources([]v1alpha1.Param{}, rtr); err != nil {
 		t.Fatalf("Did not expect to see error when validating valid resolved TaskRun but saw %v", err)
 	}
 }
 
 func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
-	rtr := &resources.ResolvedTaskResources{
-		TaskSpec: &v1alpha1.TaskSpec{
-			Steps: validBuildSteps,
-			Inputs: &v1alpha1.Inputs{
-				Params: []v1alpha1.TaskParam{{
-					Name: "foo",
-				}, {
-					Name: "bar",
-				}},
-			},
-		},
-	}
+	rtr := tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+		validBuildStepFn,
+		tb.TaskInputs(tb.InputsParam("foo"), tb.InputsParam("bar")),
+	))
 	p := []v1alpha1.Param{{
 		Name:  "foo",
 		Value: "somethinggood",
@@ -73,18 +51,10 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
-	rtr := &resources.ResolvedTaskResources{
-		TaskSpec: &v1alpha1.TaskSpec{
-			Steps: validBuildSteps,
-			Inputs: &v1alpha1.Inputs{
-				Params: []v1alpha1.TaskParam{{
-					Name: "foo",
-				}, {
-					Name: "bar",
-				}},
-			},
-		},
-	}
+	rtr := tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+		validBuildStepFn,
+		tb.TaskInputs(tb.InputsParam("foo"), tb.InputsParam("bar")),
+	))
 	p := []v1alpha1.Param{{
 		Name:  "foobar",
 		Value: "somethingfun",
@@ -95,72 +65,33 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTaskResources_InvalidResources(t *testing.T) {
-	r := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "git-test-resource",
-			Namespace: "foo",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeGit,
-			Params: []v1alpha1.Param{{
-				Name:  "foo",
-				Value: "bar",
-			}},
-		},
-	}
+	r := tb.PipelineResource("git-test-resource", "foo", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit,
+		tb.PipelineResourceSpecParam("foo", "bar"),
+	))
 	tcs := []struct {
 		name string
 		rtr  *resources.ResolvedTaskResources
 	}{{
 		name: "bad-inputkey",
-		rtr: &resources.ResolvedTaskResources{
-			TaskSpec: &v1alpha1.TaskSpec{
-				Inputs: &v1alpha1.Inputs{
-					Resources: []v1alpha1.TaskResource{{
-						Name: "testinput",
-					}},
-				},
-			},
-			Inputs: map[string]*v1alpha1.PipelineResource{"wrong-resource-name": r},
-		},
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskInputs(tb.InputsResource("testinput", v1alpha1.PipelineResourceTypeGit)),
+		), tb.ResolvedTaskResourcesInputs("wrong-resource-name", r)),
 	}, {
 		name: "bad-outputkey",
-		rtr: &resources.ResolvedTaskResources{
-			TaskSpec: &v1alpha1.TaskSpec{
-				Outputs: &v1alpha1.Outputs{
-					Resources: []v1alpha1.TaskResource{{
-						Name: "testoutput",
-					}},
-				},
-			},
-			Outputs: map[string]*v1alpha1.PipelineResource{"wrong-resource-name": r},
-		},
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskOutputs(tb.OutputsResource("testoutput", v1alpha1.PipelineResourceTypeGit)),
+		), tb.ResolvedTaskResourcesInputs("wrong-resource-name", r)),
 	}, {
 		name: "input-resource-mismatch",
-		rtr: &resources.ResolvedTaskResources{
-			TaskSpec: &v1alpha1.TaskSpec{
-				Inputs: &v1alpha1.Inputs{
-					Resources: []v1alpha1.TaskResource{{
-						Name: "testimageinput",
-						Type: v1alpha1.PipelineResourceTypeImage,
-					}},
-				},
-			},
-			Inputs: map[string]*v1alpha1.PipelineResource{"testimageinput": r},
-		},
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskInputs(tb.InputsResource("testimageinput", v1alpha1.PipelineResourceTypeImage)),
+		), tb.ResolvedTaskResourcesInputs("testimageinput", r)),
 	}, {
 		name: "output-resource-mismatch",
-		rtr: &resources.ResolvedTaskResources{
-			TaskSpec: &v1alpha1.TaskSpec{
-				Outputs: &v1alpha1.Outputs{
-					Resources: []v1alpha1.TaskResource{{
-						Name: "testimageoutput",
-						Type: v1alpha1.PipelineResourceTypeImage,
-					}},
-				},
-			},
-			Outputs: map[string]*v1alpha1.PipelineResource{"testimageoutput": r},
-		},
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskOutputs(tb.OutputsResource("testimageoutput", v1alpha1.PipelineResourceTypeImage)),
+		), tb.ResolvedTaskResourcesInputs("testimageoutput", r)),
 	}}
 
 	for _, tc := range tcs {

--- a/test/builder/examples_test.go
+++ b/test/builder/examples_test.go
@@ -77,7 +77,7 @@ func ExampleTaskRun() {
 	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", "namespace", tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
-			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef("git-resource", "a1")),
+			tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef("git-resource")),
 		),
 		tb.TaskRunTaskSpec(
 			tb.TaskInputs(
@@ -132,10 +132,10 @@ func ExamplePipelineRun() {
 
 func ExamplePipelineResource() {
 	gitResource := tb.PipelineResource("git-resource", "namespace", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeGit, tb.PipelineSpecParam("URL", "https://foo.git"),
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
 	imageResource := tb.PipelineResource("image-resource", "namespace", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeImage, tb.PipelineSpecParam("URL", "gcr.io/kristoff/sven"),
+		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
 	))
 	expectedGitResource := v1alpha1.PipelineResource{
 		// […]

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -19,19 +19,31 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	tb "github.com/knative/build-pipeline/test/builder"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPipeline(t *testing.T) {
-	pipeline := tb.Pipeline("tomatoes", "foo",
-		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
-	)
+	pipeline := tb.Pipeline("tomatoes", "foo", tb.PipelineSpec(
+		tb.PipelineTask("foo", "banana",
+			tb.PipelineTaskParam("name", "value"),
+		),
+		tb.PipelineTask("bar", "chocolate",
+			tb.PipelineTaskRefKind(v1alpha1.ClusterTaskKind),
+			tb.PipelineTaskResourceDependency("i-am", tb.ProvidedBy("foo")),
+		),
+	))
 	expectedPipeline := &v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{Name: "tomatoes", Namespace: "foo"},
 		Spec: v1alpha1.PipelineSpec{
 			Tasks: []v1alpha1.PipelineTask{{
 				Name:    "foo",
 				TaskRef: v1alpha1.TaskRef{Name: "banana"},
+				Params:  []v1alpha1.Param{{Name: "name", Value: "value"}},
+			}, {
+				Name:                 "bar",
+				TaskRef:              v1alpha1.TaskRef{Name: "chocolate", Kind: v1alpha1.ClusterTaskKind},
+				ResourceDependencies: []v1alpha1.ResourceDependency{{Name: "i-am", ProvidedBy: []string{"foo"}}},
 			}},
 		},
 	}
@@ -41,15 +53,29 @@ func TestPipeline(t *testing.T) {
 }
 
 func TestPipelineRun(t *testing.T) {
-	pipelineRun := tb.PipelineRun("pear", "foo",
-		tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccount("sa")),
-	)
+	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+		"tomatoes", tb.PipelineRunServiceAccount("sa"),
+		tb.PipelineRunTaskResource("res1",
+			tb.PipelineTaskResourceInputs("inputs"),
+			tb.PipelineTaskResourceOutputs("outputs"),
+		),
+	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+		Type: duckv1alpha1.ConditionSucceeded,
+	})))
 	expectedPipelineRun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "pear", Namespace: "foo"},
 		Spec: v1alpha1.PipelineRunSpec{
 			PipelineRef:        v1alpha1.PipelineRef{Name: "tomatoes"},
 			PipelineTriggerRef: v1alpha1.PipelineTriggerRef{Type: v1alpha1.PipelineTriggerTypeManual},
 			ServiceAccount:     "sa",
+			PipelineTaskResources: []v1alpha1.PipelineTaskResource{{
+				Name:    "res1",
+				Inputs:  []v1alpha1.TaskResourceBinding{{Name: "inputs"}},
+				Outputs: []v1alpha1.TaskResourceBinding{{Name: "outputs"}},
+			}},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			Conditions: []duckv1alpha1.Condition{{Type: duckv1alpha1.ConditionSucceeded}},
 		},
 	}
 	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {
@@ -59,7 +85,7 @@ func TestPipelineRun(t *testing.T) {
 
 func TestPipelineResource(t *testing.T) {
 	pipelineResource := tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeGit, tb.PipelineSpecParam("URL", "https://foo.git"),
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
 	expectedPipelineResource := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{Name: "git-resource", Namespace: "foo"},


### PR DESCRIPTION
- `pipelinerun_test.go`
- `taskrun/validate_test.go`

Follow-up of #319 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>