### PR TITLE
Add docs and validation for `providedBy`

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -37,6 +37,59 @@ need.
   expressed explicitly using this key since a task needing a resource from a
   another task would have to run after.
 - The name used in the `providedBy` is the name of `PipelineTask`
+- The name of the `PipelineResource` must correspond to a `PipelineResource` from
+  the `Task` that the referenced `PipelineTask` provides as an output
+
+For example see this `Pipeline` spec:
+
+```yaml
+  - name: build-skaffold-app
+    taskRef:
+      name: build-push
+    params:
+    - name: pathToDockerFile
+      value: Dockerfile
+    - name: pathToContext
+      value: /workspace/examples/microservices/leeroy-app
+  - name: deploy-app
+    taskRef:
+      name: demo-deploy-kubectl
+    resources:
+    - name: image
+      providedBy:
+      - build-skaffold-app
+```
+
+The `image` resource is expected to be provided to the `deploy-app` `Task` from the
+`build-skaffold-app` `Task`. This means that the `PipelineResource` bound to the `image`
+input for `deploy-app` must be bound to the same `PipelineResource` as an output from
+`build-skaffold-app`.
+
+This is the corresponding `PipelineRun` spec:
+
+```yaml
+  - name: build-skaffold-app
+    ...
+    outputs:
+    - name: builtImage
+      resourceRef:
+        name: skaffold-image-leeroy-app
+  - name: deploy-app
+    ...
+    - name: image
+      resourceRef:
+        name: skaffold-image-leeroy-app
+```
+
+You can see that the `builtImage` output from `build-skaffold-app` is bound to the
+`skaffold-image-leeroy-app` `PipelineResource`, and the same `PipelineResource` is bound
+to `image` for `deploy-app`.
+
+This controls two things:
+
+1. The order the `Tasks` are executed in: `deploy-app` must come after `build-skaffold-app`
+2. The state of the `PipelineResources`: the image provided to `deploy-app` may be changed
+   by `build-skaffold-app` (WIP, see [#216](https://github.com/knative/build-pipeline/issues/216))
 
 ## Creating a Task
 

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -90,7 +90,7 @@ type PipelineTaskParam struct {
 type ResourceDependency struct {
 	// Name is the name of the Task's input that this Resource should be used for.
 	Name string `json:"name"`
-	// ProvidedBy is the list of Task names that the resource has to come from.
+	// ProvidedBy is the list of PipelineTask names that the resource has to come from.
 	// +optional
 	ProvidedBy []string `json:"providedBy,omitempty"`
 }


### PR DESCRIPTION
While working on creating an end to end test for #168, @dlorenc and I
had a very hard time determining why our pipeline wasn't working as
expected - it turned out that we were using the wrong resource name in
our `providedBy` clauses.

While adding this validation I _really_ struggled to understand how the
`providedBy` clause actually works. I've updated the docs with my best
understanding of how it is currently working.

Fortunately in #320 we will be simplifying how this works!

This is follow-up work for #124