### PR TITLE
golang format tools

### DIFF
--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -240,7 +240,7 @@ func TestResolvedTaskResources(t *testing.T) {
 			}},
 		},
 		Inputs: map[string]*v1alpha1.PipelineResource{
-			"foo": &v1alpha1.PipelineResource{
+			"foo": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",
 					Namespace: "baz",


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
