### PR TITLE
Fix #332: Use lru cache to expire entrypoint items

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -387,7 +387,10 @@ func (c *Reconciler) createBuildPod(ctx context.Context, tr *v1alpha1.TaskRun, t
 
 	// For each step with no entrypoint set, try to populate it with the info
 	// from the remote registry
-	cache := entrypoint.NewCache()
+	cache, err := entrypoint.NewCache()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create new entrypoint cache: %v", err)
+	}
 	bSpec := bs.DeepCopy()
 	for i := range bSpec.Steps {
 		step := &bSpec.Steps[i]


### PR DESCRIPTION
Fix issue #332 

Use a lru cache that will only keep the most recently-used entrypoints cached and drop entrypoints haven't been used recently, in order to present a risk of DoS.

1. replace internal map in original Cache with lru.Cache
2. fix incorrect entrypoint_test package name

Signed-off-by: mathspanda <mathspanda826@gmail.com>