### PR TITLE
Fix nil pointer bug in TaskRun SetDefaults

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -21,7 +21,7 @@ func (tr *TaskRun) SetDefaults() {
 }
 
 func (trs *TaskRunSpec) SetDefaults() {
-	if trs.TaskRef.Kind == "" {
+	if trs.TaskRef != nil && trs.TaskRef.Kind == "" {
 		trs.TaskRef.Kind = NamespacedTaskKind
 	}
 }


### PR DESCRIPTION
Fix bug issue #351.

If apply a TaskRun CR without TaskRef field, webhook will panic. TaskRef.Kind will be set default value in method SetDefaults, while TaskRef is nil.