### PR TITLE
Add Pipeline-level timeouts

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -5,6 +5,7 @@
 - [How do I make Resources?](#creating-resources)
 - [How do I run a Pipeline?](#running-a-pipeline)
 - [How do I run a Task on its own?](#running-a-task)
+- [How do I ensure a Pipeline or Task stops if it runs for too long?](#timing-out-pipelines-and-tasks)
 - [How do I troubleshoot a PipelineRun?](#troubleshooting)
 - [How do I follow logs?](../test/logs/README.md)
 
@@ -989,6 +990,17 @@ Below is an example on how to create a storage resource with service account.
          secretName: bucket-sa
          secretKey: service_account.json
    ```
+
+## Timing Out Pipelines and Tasks
+
+If you want to ensure that your `Pipeline` or `Task` will be stopped if it runs
+past a certain duration, you can use the `Timeout` field on either `Pipeline`
+or `Task`. In both cases, add the following to the `spec`:
+
+```yaml
+spec:
+  timeout: 5m
+```
 
 ## Troubleshooting
 

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -23,9 +23,13 @@ import (
 
 // PipelineSpec defines the desired state of PipeLine.
 type PipelineSpec struct {
-	Resources  []PipelineDeclaredResource `json:"resources"`
-	Tasks      []PipelineTask             `json:"tasks"`
-	Generation int64                      `json:"generation,omitempty"`
+	Resources []PipelineDeclaredResource `json:"resources"`
+	Tasks     []PipelineTask             `json:"tasks"`
+	// Time after which the Pipeline times out. Defaults to never.
+	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
+	// +optional
+	Timeout    *metav1.Duration `json:"timeout,omitempty"`
+	Generation int64            `json:"generation,omitempty"`
 }
 
 // PipelineStatus does not contain anything because Pipelines on their own

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -124,5 +124,13 @@ func (ps *PipelineSpec) Validate() *apis.FieldError {
 	if err := validateFrom(ps.Tasks); err != nil {
 		return apis.ErrInvalidValue(err.Error(), "spec.tasks.resources.inputs.from")
 	}
+
+	if ps.Timeout != nil {
+		// timeout should be a valid duration of at least 0.
+		if ps.Timeout.Duration <= 0 {
+			return apis.ErrInvalidValue(fmt.Sprintf("%s should be > 0", ps.Timeout.Duration.String()), "spec.timeout")
+		}
+	}
+
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -18,9 +18,11 @@ package v1alpha1_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	tb "github.com/knative/build-pipeline/test/builder"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPipelineSpec_Validate_Error(t *testing.T) {
@@ -100,6 +102,14 @@ func TestPipelineSpec_Validate_Error(t *testing.T) {
 					tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar"))),
 			)),
 		},
+		{
+			name: "negative pipeline timeout",
+			p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+				tb.PipelineTask("foo", "foo-task"),
+				tb.PipelineTask("bar", "bar-task"),
+				tb.PipelineTimeout(&metav1.Duration{Duration: -48 * time.Hour}),
+			)),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -142,6 +152,14 @@ func TestPipelineSpec_Validate_Valid(t *testing.T) {
 					tb.PipelineTaskOutputResource("some-image", "wonderful-resource")),
 				tb.PipelineTask("foo", "foo-task",
 					tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar"))),
+			)),
+		},
+		{
+			name: "valid timeout",
+			p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+				tb.PipelineTask("foo", "foo-task"),
+				tb.PipelineTask("bar", "bar-task"),
+				tb.PipelineTimeout(&metav1.Duration{Duration: 24 * time.Hour}),
 			)),
 		},
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"time"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/knative/pkg/webhook"
@@ -107,6 +108,12 @@ type PipelineRunStatus struct {
 	// In #107 should be updated to hold the location logs have been uploaded to
 	// +optional
 	Results *Results `json:"results,omitempty"`
+	// StartTime is the time the PipelineRun is actually started.
+	// +optional
+	StartTime *metav1.Time `json:"startTime,omitempty"`
+	// CompletionTime is the time the PipelineRun completed.
+	// +optional
+	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
 	// map of TaskRun Status with the taskRun name as the key
 	//+optional
 	TaskRuns map[string]TaskRunStatus `json:"taskRuns,omitempty"`
@@ -123,6 +130,9 @@ func (pr *PipelineRunStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1a
 func (pr *PipelineRunStatus) InitializeConditions() {
 	if pr.TaskRuns == nil {
 		pr.TaskRuns = make(map[string]TaskRunStatus)
+	}
+	if pr.StartTime.IsZero() {
+		pr.StartTime = &metav1.Time{time.Now()}
 	}
 	pipelineRunCondSet.Manage(pr).InitializeConditions()
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -76,6 +76,10 @@ func TestInitializeConditions(t *testing.T) {
 		t.Fatalf("PipelineRun status not initialized correctly")
 	}
 
+	if p.Status.StartTime.IsZero() {
+		t.Fatalf("PipelineRun StartTime not initialized correctly")
+	}
+
 	p.Status.TaskRuns["fooTask"] = TaskRunStatus{}
 
 	p.Status.InitializeConditions()

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
@@ -136,6 +137,9 @@ func (tr *TaskRunStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha
 	return taskRunCondSet.Manage(tr).GetCondition(t)
 }
 func (tr *TaskRunStatus) InitializeConditions() {
+	if tr.StartTime.IsZero() {
+		tr.StartTime = &metav1.Time{time.Now()}
+	}
 	taskRunCondSet.Manage(tr).InitializeConditions()
 }
 

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -69,6 +69,7 @@ func (ts *TaskRunSpec) Validate() *apis.FieldError {
 			return err
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -575,6 +575,24 @@ func (in *PipelineRunStatus) DeepCopyInto(out *PipelineRunStatus) {
 			**out = **in
 		}
 	}
+	if in.StartTime != nil {
+		in, out := &in.StartTime, &out.StartTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
+	if in.CompletionTime != nil {
+		in, out := &in.CompletionTime, &out.CompletionTime
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Time)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	if in.TaskRuns != nil {
 		in, out := &in.TaskRuns, &out.TaskRuns
 		*out = make(map[string]TaskRunStatus, len(*in))
@@ -610,6 +628,15 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 		*out = make([]PipelineTask, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
 		}
 	}
 	return

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -184,7 +184,15 @@ func TestReconcile(t *testing.T) {
 		),
 		tb.TaskRunLabel("pipeline.knative.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("pipeline.knative.dev/pipelineRun", "test-pipeline-run-success"),
-		tb.TaskRunSpec(tb.TaskRunTaskRef("unit-test-task"),
+		tb.TaskRunSpec(tb.TaskRunTaskSpec(
+			tb.TaskInputs(
+				tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
+				tb.InputsParam("foo"), tb.InputsParam("bar"), tb.InputsParam("templatedparam"),
+			),
+			tb.TaskOutputs(
+				tb.OutputsResource("image-to-use", v1alpha1.PipelineResourceTypeImage),
+				tb.OutputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
+			)),
 			tb.TaskRunServiceAccount("test-sa"),
 			tb.TaskRunInputs(
 				tb.TaskRunInputsParam("foo", "somethingfun"),
@@ -425,8 +433,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 		})),
 	)}
 	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
-		tb.PipelineTask("hello-world-1", "hellow-world"),
-	))}
+		tb.PipelineTask("hello-world-1", "hellow-world")))}
 	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
 	d := test.Data{
 		PipelineRuns: prs,
@@ -496,6 +503,7 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 			),
 		),
 	}
+
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -517,12 +525,69 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 
 	// Check that the PipelineRun was reconciled correctly
 	reconciledRun, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-cancelled", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
-	}
 
 	// This PipelineRun should still be complete and false, and the status should reflect that
 	if !reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsFalse() {
 		t.Errorf("Expected PipelineRun status to be complete and false, but was %v", reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
+	}
+}
+
+func TestReconcileWithTimeout(t *testing.T) {
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world"),
+		tb.PipelineTimeout(&metav1.Duration{Duration: 12 * time.Hour}),
+	))}
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", "foo",
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccount("test-sa"),
+		),
+		tb.PipelineRunStatus(
+			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
+	)}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+	}
+
+	// create fake recorder for testing
+	fr := record.NewFakeRecorder(2)
+
+	testAssets := getPipelineRunController(d, fr)
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-with-timeout")
+	if err != nil {
+		t.Errorf("Did not expect to see error when reconciling completed PipelineRun but saw %s", err)
+	}
+
+	// Check that the PipelineRun was reconciled correctly
+	reconciledRun, err := clients.Pipeline.Pipeline().PipelineRuns("foo").Get("test-pipeline-run-with-timeout", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+
+	// The PipelineRun should be timed out.
+	if reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded).Reason != resources.ReasonTimedOut {
+		t.Errorf("Expected PipelineRun to be timed out, but condition reason is %s", reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
+	}
+
+	// Check that the expected TaskRun was created
+	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject().(*v1alpha1.TaskRun)
+	if actual == nil {
+		t.Errorf("Expected a TaskRun to be created, but it wasn't.")
+	}
+
+	// There should be a time out for the TaskRun
+	if actual.Spec.TaskSpec.Timeout == nil {
+		t.Fatalf("TaskSpec.Timeout shouldn't be nil")
+	}
+
+	// The TaskRun timeout should be less than or equal to the PipelineRun timeout.
+	if actual.Spec.TaskSpec.Timeout.Duration > ps[0].Spec.Timeout.Duration {
+		t.Errorf("TaskRun timeout %s should be less than or equal to PipelineRun timeout %s", actual.Spec.TaskSpec.Timeout.Duration.String(), ps[0].Spec.Timeout.Duration.String())
 	}
 }

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -671,7 +672,8 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			c := GetPipelineConditionStatus("somepipelinerun", tc.state, zap.NewNop().Sugar())
+			c := GetPipelineConditionStatus("somepipelinerun", tc.state, zap.NewNop().Sugar(), &metav1.Time{time.Now()},
+				nil)
 			if c.Status != tc.expectedStatus {
 				t.Fatalf("Expected to get status %s but got %s for state %v", tc.expectedStatus, c.Status, tc.state)
 			}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -17,6 +17,7 @@ import (
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
 )
 
 // PipelineOp is an operation which modify a Pipeline struct.
@@ -111,6 +112,13 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 			op(pTask)
 		}
 		ps.Tasks = append(ps.Tasks, *pTask)
+	}
+}
+
+// PipelineTimeout sets the timeout to the PipelineSpec.
+func PipelineTimeout(duration *metav1.Duration) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		ps.Timeout = duration
 	}
 }
 
@@ -257,6 +265,13 @@ func PipelineRunStatus(ops ...PipelineRunStatusOp) PipelineRunOp {
 func PipelineRunStatusCondition(condition duckv1alpha1.Condition) PipelineRunStatusOp {
 	return func(s *v1alpha1.PipelineRunStatus) {
 		s.Conditions = append(s.Conditions, condition)
+	}
+}
+
+// PipelineRunStartTime sets the start time to the PipelineRunStatus.
+func PipelineRunStartTime(startTime time.Time) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		s.StartTime = &metav1.Time{Time: startTime}
 	}
 }
 

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -15,6 +15,7 @@ package builder_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
@@ -35,6 +36,7 @@ func TestPipeline(t *testing.T) {
 			tb.PipelineTaskInputResource("some-repo", "my-only-git-resource", tb.From("foo")),
 			tb.PipelineTaskOutputResource("some-image", "my-only-image-resource"),
 		),
+		tb.PipelineTimeout(&metav1.Duration{Duration: 1 * time.Hour}),
 	))
 	expectedPipeline := &v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{Name: "tomatoes", Namespace: "foo"},
@@ -65,6 +67,7 @@ func TestPipeline(t *testing.T) {
 					}},
 				},
 			}},
+			Timeout: &metav1.Duration{Duration: 1 * time.Hour},
 		},
 	}
 	if d := cmp.Diff(expectedPipeline, pipeline); d != "" {
@@ -73,12 +76,13 @@ func TestPipeline(t *testing.T) {
 }
 
 func TestPipelineRun(t *testing.T) {
+	startTime := time.Now()
 	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccount("sa"),
 		tb.PipelineRunResourceBinding("some-resource", tb.PipelineResourceBindingRef("my-special-resource")),
 	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
 		Type: duckv1alpha1.ConditionSucceeded,
-	})))
+	}), tb.PipelineRunStartTime(startTime)))
 	expectedPipelineRun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "pear", Namespace: "foo"},
 		Spec: v1alpha1.PipelineRunSpec{
@@ -94,6 +98,7 @@ func TestPipelineRun(t *testing.T) {
 		},
 		Status: v1alpha1.PipelineRunStatus{
 			Conditions: []duckv1alpha1.Condition{{Type: duckv1alpha1.ConditionSucceeded}},
+			StartTime: &metav1.Time{Time: startTime},
 		},
 	}
 	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -312,6 +312,13 @@ func StepState(ops ...StepStateOp) TaskRunStatusOp {
 	}
 }
 
+// TaskRunStartTime sets the start time to the TaskRunStatus.
+func TaskRunStartTime(startTime time.Time) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.StartTime = &metav1.Time{Time: startTime}
+	}
+}
+
 // StateTerminated set Terminated to the StepState.
 func StateTerminated(exitcode int) StepStateOp {
 	return func(s *v1alpha1.StepState) {

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -1,0 +1,151 @@
+// +build e2e
+
+/*
+Copyright 2019 Knative Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
+	tb "github.com/knative/build-pipeline/test/builder"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	knativetest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestPipelineRunTimeout is an integration test that will
+// verify that pipelinerun timeout works and leads to the the correct TaskRun statuses
+// and pod deletions.
+func TestPipelineRunTimeout(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	c, namespace := setup(t, logger)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
+
+	logger.Infof("Creating Task in namespace %s", namespace)
+	task := tb.Task("banana", namespace, tb.TaskSpec(
+		tb.Step("foo", "busybox", tb.Command("sleep"), tb.Args("10"))))
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", hwTaskName, err)
+	}
+
+	pipeline := tb.Pipeline("tomatoes", namespace,
+		tb.PipelineSpec(tb.PipelineTask("foo", "banana"),
+			tb.PipelineTimeout(&metav1.Duration{Duration: 5 * time.Second}),
+		),
+	)
+	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
+	}
+
+	logger.Infof("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+		c := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
+				return true, fmt.Errorf("pipelineRun %s already finished!", pipelineRun.Name)
+			} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "PipelineRunRunning"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
+	}
+
+	trName := fmt.Sprintf("%s-%s", pipelineRun.Name, task.Spec.Steps[0].Name)
+
+	logger.Infof("Waiting for TaskRun %s in namespace %s to be running", trName, namespace)
+	if err := WaitForTaskRunState(c, trName, func(tr *v1alpha1.TaskRun) (bool, error) {
+		c := tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
+				return true, fmt.Errorf("taskRun %s already finished!", trName)
+			} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "TaskRunRunning"); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to be running: %s", trName, err)
+	}
+
+	if _, err := c.PipelineRunClient.Get(pipelineRun.Name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
+	}
+
+	logger.Infof("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+		c := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionFalse {
+				if c.Reason == resources.ReasonTimedOut {
+					return true, nil
+				}
+				return true, fmt.Errorf("pipelineRun %s completed with the wrong reason: %s", pipelineRun.Name, c.Reason)
+			} else if c.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("pipelineRun %s completed successfully, should have been timed out", pipelineRun.Name)
+			}
+		}
+		return false, nil
+	}, "PipelineRunTimedOut"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", trName, err)
+	}
+
+	logger.Infof("Waiting for TaskRun %s in namespace %s to be cancelled", trName, namespace)
+	if err := WaitForTaskRunState(c, trName, func(tr *v1alpha1.TaskRun) (bool, error) {
+		cond := tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		if cond != nil {
+			if cond.Status == corev1.ConditionFalse {
+				if cond.Reason == "TaskRunTimeout" {
+					return true, nil
+				}
+				return true, fmt.Errorf("taskRun %s completed with the wrong reason: %s", trName, cond.Reason)
+			} else if cond.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("taskRun %s completed successfully, should have been timed out", trName)
+			}
+		}
+		return false, nil
+	}, "TaskRunTimeout"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", trName, err)
+	}
+
+	// Verify that we can create a second Pipeline using the same Task without a Pipeline-level timeout that will not
+	// time out
+	secondPipeline := tb.Pipeline("peppers", namespace,
+		tb.PipelineSpec(tb.PipelineTask("foo", "banana")))
+	secondPipelineRun := tb.PipelineRun("kiwi", namespace, tb.PipelineRunSpec("peppers"))
+	if _, err := c.PipelineClient.Create(secondPipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline `%s`: %s", secondPipeline.Name, err)
+	}
+	if _, err := c.PipelineRunClient.Create(secondPipelineRun); err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", secondPipelineRun.Name, err)
+	}
+
+	logger.Infof("Waiting for PipelineRun %s in namespace %s to complete", secondPipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, secondPipelineRun.Name, pipelineRunTimeout, PipelineRunSucceed(secondPipelineRun.Name), "PipelineRunSuccess"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", secondPipelineRun.Name, err)
+	}
+}


### PR DESCRIPTION
This allows configuring `Pipeline` timeouts that will be enforced for their `TaskRun`s appropriately as well, and also replicates `Build`'s timeout behavior on `TaskRun`, since that didn't actually get moved over here earlier.

Fixes #222