### PR TITLE
Fixes #186: Use Event Recorder to verify failure cases instead of logs 

### DIFF
--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
+	"github.com/knative/build-pipeline/test"
+	tb "github.com/knative/build-pipeline/test/builder"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+// Test case for providing recorder in the option
+func TestRecorderOptions(t *testing.T) {
+
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
+		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccount("test-sa")),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:    duckv1alpha1.ConditionSucceeded,
+			Status:  corev1.ConditionTrue,
+			Reason:  resources.ReasonSucceeded,
+			Message: "All Tasks have completed executing",
+		})),
+	)}
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hellow-world"),
+	))}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+	}
+	c, _ := test.SeedTestData(d)
+
+	observer, _ := observer.New(zap.InfoLevel)
+
+	// recorder is ont provided in the option
+	b := NewBase(Options{
+		Logger:            zap.New(observer).Sugar(),
+		KubeClientSet:     c.Kube,
+		PipelineClientSet: c.Pipeline,
+	}, "test")
+
+	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.recorderImpl") != 0 {
+		t.Errorf("Expected recorder type '*record.recorderImpl' but actual type is: %s", reflect.TypeOf(b.Recorder).String())
+	}
+
+	fr := record.NewFakeRecorder(1)
+
+	// recorder is provided in the option
+	b = NewBase(Options{
+		Logger:            zap.New(observer).Sugar(),
+		KubeClientSet:     c.Kube,
+		PipelineClientSet: c.Pipeline,
+		Recorder:          fr,
+	}, "test")
+
+	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.FakeRecorder") != 0 {
+		t.Errorf("Expected recorder type '*record.FakeRecorder' but actual type is: %s", reflect.TypeOf(b.Recorder).String())
+	}
+}


### PR DESCRIPTION
This issue is suggested by https://github.com/knative/build-pipeline/issues/186.  In pipelinerun_test, we are using log observer to verify certain negative test cases.   We could instead refactor to inject fake recorder to generate events and then validate these events in the tests.

In reconciler.go, a recorder can be passed as an option.   If a recorder is presented in the option, it will be used.  Otherwise, a new recorder is created which keeps the old behaviour the same.   As mentioned, pipelinerun_test.go will pass a fake recorder in Reconciler's options.

Reconcile() can still return errors.   I am not sure if we want to change the method's return type at this point.  Especially, the method can fail/return before the pipeline run object can be obtained which is needed in order to log an event.

