### PR TITLE
Use test builders and fix `providedBy` example 👷‍♀️

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -77,6 +77,7 @@ This is the corresponding `PipelineRun` spec:
         name: skaffold-image-leeroy-app
   - name: deploy-app
     ...
+    inputs:
     - name: image
       resourceRef:
         name: skaffold-image-leeroy-app

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
+	tb "github.com/knative/build-pipeline/test/builder"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -563,14 +564,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 }
 
 func TestValidateProvidedBy(t *testing.T) {
-	r := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holygrail",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeImage,
-		},
-	}
+	r := tb.PipelineResource("holygrail", namespace, tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage))
 	state := []*ResolvedPipelineRunTask{{
 		PipelineTask: &v1alpha1.PipelineTask{
 			Name: "quest",
@@ -616,22 +610,8 @@ func TestValidateProvidedBy(t *testing.T) {
 }
 
 func TestValidateProvidedBy_Invalid(t *testing.T) {
-	r := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holygrail",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeImage,
-		},
-	}
-	otherR := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "holyhandgrenade",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeImage,
-		},
-	}
+	r := tb.PipelineResource("holygrail", namespace, tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage))
+	otherR := tb.PipelineResource("holyhandgrenade", namespace, tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage))
 
 	for _, tc := range []struct {
 		name  string

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -494,12 +494,22 @@ func ResolvedTaskResourcesTaskSpec(ops ...TaskSpecOp) ResolvedTaskResourcesOp {
 	}
 }
 
-// ResolvedTaskResourcesInputs adds a PipelineResource, with specified name, to the ResolvedTaskResources.
+// ResolvedTaskResourcesInputs adds an input PipelineResource, with specified name, to the ResolvedTaskResources.
 func ResolvedTaskResourcesInputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
 	return func(r *resources.ResolvedTaskResources) {
 		if r.Inputs == nil {
 			r.Inputs = map[string]*v1alpha1.PipelineResource{}
 		}
 		r.Inputs[name] = resource
+	}
+}
+
+// ResolvedTaskResourcesOutputs adds an output PipelineResource, with specified name, to the ResolvedTaskResources.
+func ResolvedTaskResourcesOutputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
+	return func(r *resources.ResolvedTaskResources) {
+		if r.Outputs == nil {
+			r.Outputs = map[string]*v1alpha1.PipelineResource{}
+		}
+		r.Outputs[name] = resource
 	}
 }


### PR DESCRIPTION
In https://github.com/knative/build-pipeline/pull/342 I added docs and
validation for the `providedBy` field, but I missed some feedback from
@vdemeester before the PR was merged, so I'm addressing it now!

The change to use the builders, for`PipelineResources` and `ResolvedTaskResources`,
removes a surprising amount of boilerplate!

While making this change I also realized that the wrong resources were
being bound, which would still result in an error, but not the error
that the tests were actually trying to exercise. So I added some very
crude assertions on the message in the error to make sure we are
exercising the right errors in the future. I considered using custom
error types instead but asserting on the strings is simple and works for
now.

One issue I ran into with the builders - I wanted to use a
`PipelineTask` builder, but the function `PipelineTask` in the builder
package only works as a modifier for a `Pipeline`.