### PR TITLE
Fix botched rename of PipelineTrigger field 😢

### DIFF
--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -274,7 +274,7 @@ func getHelmDeployPipelineRun(namespace string) *v1alpha1.PipelineRun {
 			PipelineRef: v1alpha1.PipelineRef{
 				Name: helmDeployPipelineName,
 			},
-			PipelineTrigger: v1alpha1.PipelineTrigger{
+			Trigger: v1alpha1.PipelineTrigger{
 				Type: v1alpha1.PipelineTriggerTypeManual,
 			},
 			PipelineTaskResources: []v1alpha1.PipelineTaskResource{{

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -463,7 +463,7 @@ func getFanInFanOutPipelineRun(suffix int, namespace string) *v1alpha1.PipelineR
 			PipelineRef: v1alpha1.PipelineRef{
 				Name: getName(hwPipelineName, suffix),
 			},
-			PipelineTrigger: v1alpha1.PipelineTrigger{
+			Trigger: v1alpha1.PipelineTrigger{
 				Type: v1alpha1.PipelineTriggerTypeManual,
 			},
 			PipelineTaskResources: []v1alpha1.PipelineTaskResource{
@@ -590,7 +590,7 @@ func getHelloWorldPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRu
 			PipelineRef: v1alpha1.PipelineRef{
 				Name: getName(hwPipelineName, suffix),
 			},
-			PipelineTrigger: v1alpha1.PipelineTrigger{
+			Trigger: v1alpha1.PipelineTrigger{
 				Type: v1alpha1.PipelineTriggerTypeManual,
 			},
 			ServiceAccount: fmt.Sprintf("%s%d", hwSA, suffix),


### PR DESCRIPTION
In #366 I tried to rename the trigger field in a `PipelineRun.Spec` from
`PipelineTrigger` to just `Trigger` to be in line with the similar
`Trigger` field in `TaskRun.Spec` BUT I MISSED SOME OF THEM 😭😭😭

Fixes #366