### PR TITLE
Remove parallelization flag from `gsutil`

### DIFF
--- a/cmd/gsutil/main.go
+++ b/cmd/gsutil/main.go
@@ -65,7 +65,7 @@ func main() {
 
 	logger.Infof("gsutil binary at path %s", gsutilPath)
 
-	cmd := exec.Command("gsutil", "-m")
+	cmd := exec.Command("gsutil")
 	cmd.Args = append(cmd.Args, strings.Split(*args, " ")...)
 
 	stdoutStderr, err := cmd.CombinedOutput()


### PR DESCRIPTION
It turns out that if you run the `gsutil` executable via
`google/cloud-sdk:alpine` with the `-m` (parallel) option, and `gsutil`
encounters an error, it will hang indefinitely.

This is almost definitely a bug to address upstream in `gsutil` itself
or in the way the `cloud-sdk` image is built, but in the meantime while
we figure out how to fix it for real (definitely we want to be able to
take advantage of parallel uploads if we can!) I'm removing the flag so
that when there are errors, folks using the GCS output resource can
debug them.

This is a stopgap measure for #372 

@mgreau @shashwathi 