### PR TITLE
golang format tools

### DIFF
--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -247,7 +247,7 @@ func TestResolvedTaskResources(t *testing.T) {
 			},
 		},
 		Outputs: map[string]*v1alpha1.PipelineResource{
-			"qux": &v1alpha1.PipelineResource{
+			"qux": {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "quux",
 					Namespace: "quuz",

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -73,8 +73,8 @@ func TestPipelineRun(t *testing.T) {
 		expectedTaskRuns: []string{"create-file-kritis", "create-fan-out-1", "create-fan-out-2", "check-fan-in"},
 		// 1 from PipelineRun and 4 from Tasks defined in pipelinerun
 		expectedNumberOfEvents: 5,
-        }}
-        // TODO(#375): Reenable the 'fan-in and fan-out' test once it's fixed.
+	}}
+	// TODO(#375): Reenable the 'fan-in and fan-out' test once it's fixed.
 	tds = []tests{{
 		name: "service account propagation",
 		testSetup: func(c *clients, namespace string, index int) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
