### PR TITLE
Add possibility for a client to cancel a {task,pipeline}run

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -360,6 +360,22 @@ secrets:
   - name: test-git-ssh
 ```
 
+### Cancelling a PipelineRun
+
+In order to cancel a running pipeline (`PipelineRun`), you need to
+updated its spec to mark it as cancelled. Related `TaskRun` will be
+marked as cancelled and building Pods deleted. 
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "PipelineRunCancelled"
+```
+
 ## Running a Task
 
 1. To run a `Task`, create a new `TaskRun` which defines all inputs, outputs
@@ -441,6 +457,21 @@ metadata:
   name: test-build-robot-git-ssh
 secrets:
   - name: test-git-ssh
+```
+
+### Cancelling a TaskRun
+
+In order to cancel a running task (`TaskRun`), you need to
+updated its spec to mark it as cancelle, building Pods deleted. 
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "TaskRunCancelled"
 ```
 
 ## Creating Resources

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -49,7 +49,19 @@ type PipelineRunSpec struct {
 	// +optional
 	Results    *Results `json:"results,omitempty"`
 	Generation int64    `json:"generation,omitempty"`
+	// Used for cancelling a pipelinerun (and maybe more later on)
+	// +optional
+	Status PipelineRunSpecStatus
 }
+
+// PipelineRunSpecStatus defines the pipelinerun spec status the user can provide
+type PipelineRunSpecStatus string
+
+const (
+	// PipelineRunSpecStatusCancelled indicates that the user wants to cancel the task,
+	// if not already cancelled or terminated
+	PipelineRunSpecStatusCancelled = "PipelineRunCancelled"
+)
 
 // PipelineTaskResource maps Task inputs and outputs to existing PipelineResources by their names.
 type PipelineTaskResource struct {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -49,9 +49,21 @@ type TaskRunSpec struct {
 	// no more than one of the TaskRef and TaskSpec may be specified.
 	// +optional
 	TaskRef *TaskRef `json:"taskRef,omitempty"`
-	//+optional
+	// +optional
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
+	// Used for cancelling a taskrun (and maybe more later on)
+	// +optional
+	Status TaskRunSpecStatus
 }
+
+// TaskRunSpecStatus defines the taskrun spec status the user can provide
+type TaskRunSpecStatus string
+
+const (
+	// TaskRunSpecStatusCancelled indicates that the user wants to cancel the task,
+	// if not already cancelled or terminated
+	TaskRunSpecStatusCancelled = "TaskRunCancelled"
+)
 
 // TaskRunInputs holds the input values that this task was invoked with.
 type TaskRunInputs struct {

--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/knative/build-pipeline/pkg/client/clientset/versioned"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// isCancelled returns true if the PipelineRun's spec indicates it is cancelled
+func isCancelled(spec v1alpha1.PipelineRunSpec) bool {
+	return spec.Status == v1alpha1.PipelineRunSpecStatusCancelled
+}
+
+// cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
+func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask, clientSet clientset.Interface) error {
+	pr.Status.SetCondition(&duckv1alpha1.Condition{
+		Type:    duckv1alpha1.ConditionSucceeded,
+		Status:  corev1.ConditionFalse,
+		Reason:  "PipelineRunCancelled",
+		Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
+	})
+	errs := []string{}
+	for _, rprt := range pipelineState {
+		if rprt.TaskRun == nil {
+			// No taskrun yet, pass
+			continue
+		}
+		rprt.TaskRun.Spec.Status = v1alpha1.TaskRunSpecStatusCancelled
+		if _, err := clientSet.PipelineV1alpha1().TaskRuns(pr.Namespace).Update(rprt.TaskRun); err != nil {
+			errs = append(errs, err.Error())
+			continue
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("Error cancelled PipelineRun's TaskRun(s): %s", strings.Join(errs, "\n"))
+	}
+	return nil
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"testing"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
+	"github.com/knative/build-pipeline/test"
+	tb "github.com/knative/build-pipeline/test/builder"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCancelPipelineRun(t *testing.T) {
+	testCases := []struct {
+		name          string
+		pipelineRun   *v1alpha1.PipelineRun
+		pipelineState []*resources.ResolvedPipelineRunTask
+		taskRuns      []*v1alpha1.TaskRun
+	}{{
+		name: "no-resolved-taskrun",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+			tb.PipelineRunSpec("test-pipeline",
+				tb.PipelineRunCancelled,
+			),
+		),
+	}, {
+		name: "1-of-resolved-taskrun",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+			tb.PipelineRunSpec("test-pipeline",
+				tb.PipelineRunCancelled,
+			),
+		),
+		pipelineState: []*resources.ResolvedPipelineRunTask{
+			&resources.ResolvedPipelineRunTask{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			&resources.ResolvedPipelineRunTask{TaskRunName: "t2"},
+		},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo")},
+	}, {
+		name: "resolved-taskruns",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+			tb.PipelineRunSpec("test-pipeline",
+				tb.PipelineRunCancelled,
+			),
+		),
+		pipelineState: []*resources.ResolvedPipelineRunTask{
+			&resources.ResolvedPipelineRunTask{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			&resources.ResolvedPipelineRunTask{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", "foo")},
+		},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo"), tb.TaskRun("t2", "foo")},
+	}}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				PipelineRuns: []*v1alpha1.PipelineRun{tc.pipelineRun},
+				TaskRuns:     tc.taskRuns,
+			}
+			c, _ := test.SeedTestData(d)
+			err := cancelPipelineRun(tc.pipelineRun, tc.pipelineState, c.Pipeline)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// This PipelineRun should still be complete and false, and the status should reflect that
+			cond := tc.pipelineRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+			if cond.IsTrue() {
+				t.Errorf("Expected PipelineRun status to be complete and false, but was %v", cond)
+			}
+			l, err := c.Pipeline.PipelineV1alpha1().TaskRuns("foo").List(metav1.ListOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, tr := range l.Items {
+				if tr.Spec.Status != v1alpha1.TaskRunSpecStatusCancelled {
+					t.Errorf("expected task %q to be marked as cancelled, was %q", tr.Name, tr.Spec.Status)
+				}
+			}
+		})
+	}
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -241,6 +241,11 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 		return fmt.Errorf("error getting TaskRuns for Pipeline %s: %s", p.Name, err)
 	}
 
+	// If the pipelinerun is cancelled, cancel tasks and update status
+	if isCancelled(pr.Spec) {
+		return cancelPipelineRun(pr, pipelineState, c.PipelineClientSet)
+	}
+
 	serviceAccount := pr.Spec.ServiceAccount
 	rprt := resources.GetNextTask(pr.Name, pipelineState, c.Logger)
 

--- a/pkg/reconciler/v1alpha1/taskrun/cancel.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"fmt"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type logger interface {
+	Warn(args ...interface{})
+	Warnf(template string, args ...interface{})
+}
+
+// isCancelled returns true if the TaskRun's' spec indicates it is cancelled
+func isCancelled(spec v1alpha1.TaskRunSpec) bool {
+	return spec.Status == v1alpha1.TaskRunSpecStatusCancelled
+}
+
+// cancelTaskRun marks the TaskRun as cancelled and delete pods linked to it.
+func cancelTaskRun(tr *v1alpha1.TaskRun, clientSet kubernetes.Interface, logger logger) error {
+	logger.Warn("task run %q has been cancelled", tr.Name)
+	tr.Status.SetCondition(&duckv1alpha1.Condition{
+		Type:    duckv1alpha1.ConditionSucceeded,
+		Status:  corev1.ConditionFalse,
+		Reason:  "TaskRunCancelled",
+		Message: fmt.Sprintf("TaskRun %q was cancelled", tr.Name),
+	})
+
+	if tr.Status.PodName == "" {
+		logger.Warnf("task run %q has no pod running yet", tr.Name)
+		return nil
+	}
+
+	if err := clientSet.CoreV1().Pods(tr.Namespace).Delete(tr.Status.PodName, &metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/knative/build-pipeline/test"
+	tb "github.com/knative/build-pipeline/test/builder"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCancelTaskRun(t *testing.T) {
+	testCases := []struct {
+		name           string
+		taskRun        *v1alpha1.TaskRun
+		pod            *corev1.Pod
+		expectedStatus duckv1alpha1.Condition
+	}{{
+		name: "no-pod-scheduled",
+		taskRun: tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
+			tb.TaskRunTaskRef(simpleTask.Name),
+			tb.TaskRunCancelled,
+		), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}))),
+		expectedStatus: duckv1alpha1.Condition{
+			Type:    duckv1alpha1.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  "TaskRunCancelled",
+			Message: `TaskRun "test-taskrun-run-cancelled" was cancelled`,
+		},
+	}, {
+		name: "pod-scheduled",
+		taskRun: tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
+			tb.TaskRunTaskRef(simpleTask.Name),
+			tb.TaskRunCancelled,
+		), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+		}), tb.PodName("foo-is-bar"))),
+		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "foo-is-bar",
+		}},
+		expectedStatus: duckv1alpha1.Condition{
+			Type:    duckv1alpha1.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  "TaskRunCancelled",
+			Message: `TaskRun "test-taskrun-run-cancelled" was cancelled`,
+		},
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := test.Data{
+				TaskRuns: []*v1alpha1.TaskRun{tc.taskRun},
+			}
+			if tc.pod != nil {
+				d.Pods = []*corev1.Pod{tc.pod}
+			}
+
+			observer, _ := observer.New(zap.InfoLevel)
+			c, _ := test.SeedTestData(d)
+			err := cancelTaskRun(tc.taskRun, c.Kube, zap.New(observer).Sugar())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d := cmp.Diff(tc.taskRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded), &tc.expectedStatus, ignoreLastTransitionTime); d != "" {
+				t.Fatalf("-want, +got: %v", d)
+			}
+		})
+	}
+}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -80,6 +80,11 @@ func PipelineSpec(ops ...PipelineSpecOp) PipelineOp {
 	}
 }
 
+// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
+func PipelineRunCancelled(spec *v1alpha1.PipelineRunSpec) {
+	spec.Status = v1alpha1.PipelineRunSpecStatusCancelled
+}
+
 // PipelineTask adds a PipelineTask, with specified name and task name, to the PipelineSpec.
 // Any number of PipelineTask modifier can be passed to transform it.
 func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -371,6 +371,11 @@ func TaskRunSpec(ops ...TaskRunSpecOp) TaskRunOp {
 	}
 }
 
+// TaskRunCancelled sets the status to cancel to the TaskRunSpec.
+func TaskRunCancelled(spec *v1alpha1.TaskRunSpec) {
+	spec.Status = v1alpha1.TaskRunSpecStatusCancelled
+}
+
 // TaskRunTaskRef sets the specified Task reference to the TaskRunSpec.
 // Any number of TaskRef modifier can be passed to transform it.
 func TaskRunTaskRef(name string, ops ...TaskRefOp) TaskRunSpecOp {


### PR DESCRIPTION
- on a `TaskRun`, clean the resources (pods) started from it
- on a `PipelineRun`, mark all "existing" resolved `TaskRun` as
  cancelled (so the `TaskRun` reconcilier takes care of that)

Porting knative/build#510 to `build-pipeline`

Making as `WIP` as I want to add an e2e tests on that :angel: 

cc @bobcatfish @abayer @shashwathi 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>