### PR TITLE
Fix GCS resource authentication bug

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -216,12 +216,8 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			TypeDir:        true,
 			Secrets: []SecretParam{{
 				SecretName: "secretName",
-				FieldName:  "fieldName",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
-			}, {
-				SecretKey:  "key.json",
-				SecretName: "secretNameSomethingelse",
-				FieldName:  "GOOGLE_ANOTHER_CREDENTIALS",
 			}},
 		},
 		wantContainers: []corev1.Container{{
@@ -229,18 +225,12 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			Image: "override-with-gsutil-image:latest",
 			Args:  []string{"-args", "cp -r gs://some-bucket/** /workspace"},
 			Env: []corev1.EnvVar{{
-				Name:  "FIELDNAME",
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",
-			}, {
-				Name:  "GOOGLE_ANOTHER_CREDENTIALS",
-				Value: "/var/secret/secretNameSomethingelse/key.json",
 			}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",
 				MountPath: "/var/secret/secretName",
-			}, {
-				Name:      "volume-gcs-valid-secretNameSomethingelse",
-				MountPath: "/var/secret/secretNameSomethingelse",
 			}},
 		}},
 	}, {
@@ -256,7 +246,7 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			}, {
 				SecretKey:  "key.json",
 				SecretName: "secretName",
-				FieldName:  "GOOGLE_ANOTHER_CREDENTIALS",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
 		},
 		wantContainers: []corev1.Container{{
@@ -264,10 +254,7 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			Image: "override-with-gsutil-image:latest",
 			Args:  []string{"-args", "cp gs://some-bucket /workspace"},
 			Env: []corev1.EnvVar{{
-				Name:  "FIELDNAME",
-				Value: "/var/secret/secretName/key.json",
-			}, {
-				Name:  "GOOGLE_ANOTHER_CREDENTIALS",
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",
 			}},
 			VolumeMounts: []corev1.VolumeMount{{
@@ -311,7 +298,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			TypeDir:        true,
 			Secrets: []SecretParam{{
 				SecretName: "secretName",
-				FieldName:  "fieldName",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
 			}},
 		},
@@ -319,7 +306,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			Name:  "storage-upload-gcs-valid",
 			Image: "override-with-gsutil-image:latest",
 			Args:  []string{"-args", "cp -r /workspace/* gs://some-bucket"},
-			Env:   []corev1.EnvVar{{Name: "FIELDNAME", Value: "/var/secret/secretName/key.json"}},
+			Env:   []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",
 				MountPath: "/var/secret/secretName",
@@ -333,12 +320,12 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			DestinationDir: "/workspace",
 			Secrets: []SecretParam{{
 				SecretName: "secretName",
-				FieldName:  "fieldName",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
 			}, {
 				SecretKey:  "key.json",
 				SecretName: "secretName",
-				FieldName:  "GOOGLE_ANOTHER_CREDENTIALS",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
 		},
 		wantContainers: []corev1.Container{{
@@ -346,8 +333,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			Image: "override-with-gsutil-image:latest",
 			Args:  []string{"-args", "cp /workspace/* gs://some-bucket"},
 			Env: []corev1.EnvVar{
-				{Name: "FIELDNAME", Value: "/var/secret/secretName/key.json"},
-				{Name: "GOOGLE_ANOTHER_CREDENTIALS", Value: "/var/secret/secretName/key.json"},
+				{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"},
 			},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -135,7 +135,7 @@ func setUp() {
 			SecretParams: []v1alpha1.SecretParam{{
 				SecretKey:  "key.json",
 				SecretName: "secret-name",
-				FieldName:  "GOOGLE_CREDENTIALS",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}, {
 				SecretKey:  "token",
 				SecretName: "secret-name2",
@@ -967,12 +967,10 @@ func Test_StorageInputResource(t *testing.T) {
 					Args:  []string{"-args", "cp -r gs://fake-bucket/rules.zip/** /workspace/storage-gcs-keys"},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"}, {
-						Name: "volume-storage-gcs-keys-secret-name2", MountPath: "/var/secret/secret-name2"}, {
 						Name: "workspace", MountPath: "/workspace"},
 					},
 					Env: []corev1.EnvVar{
-						{Name: "GOOGLE_CREDENTIALS", Value: "/var/secret/secret-name/key.json"},
-						{Name: "GOOGLE_TOKEN", Value: "/var/secret/secret-name2/token"},
+						{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secret-name/key.json"},
 					},
 				}},
 				Volumes: []corev1.Volume{{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -82,7 +82,7 @@ func outputResourcesetUp() {
 			SecretParams: []v1alpha1.SecretParam{{
 				SecretKey:  "key.json",
 				SecretName: "sname",
-				FieldName:  "STORAGE_CREDS",
+				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
 		},
 	}}
@@ -326,7 +326,7 @@ func Test_Valid_OutputResources(t *testing.T) {
 			}},
 			Args: []string{"-args", "cp -r /workspace/faraway-disk/* gs://some-bucket"},
 			Env: []corev1.EnvVar{{
-				Name: "STORAGE_CREDS", Value: "/var/secret/sname/key.json",
+				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 		}, {
 			Name:         "source-mkdir-source-gcs",
@@ -393,7 +393,7 @@ func Test_Valid_OutputResources(t *testing.T) {
 				Name: "workspace", MountPath: "/workspace",
 			}},
 			Env: []corev1.EnvVar{{
-				Name: "STORAGE_CREDS", Value: "/var/secret/sname/key.json",
+				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}, {
@@ -457,7 +457,7 @@ func Test_Valid_OutputResources(t *testing.T) {
 				Name: "workspace", MountPath: "/workspace",
 			}},
 			Env: []corev1.EnvVar{{
-				Name: "STORAGE_CREDS", Value: "/var/secret/sname/key.json",
+				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}},
@@ -510,7 +510,7 @@ func Test_Valid_OutputResources(t *testing.T) {
 				Name: "workspace", MountPath: "/workspace",
 			}},
 			Env: []corev1.EnvVar{{
-				Name: "STORAGE_CREDS", Value: "/var/secret/sname/key.json",
+				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}},

--- a/test/README.md
+++ b/test/README.md
@@ -104,17 +104,21 @@ pipelineRunsInformer.Informer().GetIndexer().Add(obj)
 
 ### Setup
 
-Besides the environment variable `KO_DOCKER_REPO`, you may also need the
-permissions inside the Build to run the Kaniko e2e test. If so, setting
-`KANIKO_SECRET_CONFIG_FILE` as the path of the GCP service account JSON key
-which has permissions to push to the registry specified in `KO_DOCKER_REPO` will
-enable Kaniko to use those credentials when pushing.
+Besides the environment variable `KO_DOCKER_REPO`, you may also need the permissions 
+inside the TaskRun to run the Kaniko e2e test and GCS taskrun test.
+- In Kaniko e2e test, setting `KANIKO_SECRET_CONFIG_FILE` as the path of the GCP service account 
+JSON key which has permissions to push to the registry specified in `KO_DOCKER_REPO` will 
+enable Kaniko to use those credentials when pushing an image.
+- In GCS taskrun test, GCP service account JSON key file at path `KANIKO_SECRET_CONFIG_FILE` is used to generate 
+Kubernetes secret to access GCS bucket. This e2e test requires valid service account configuration 
+json but it does not require any role binding. 
 
-To create a service account usable in the e2e tests:
+To reduce e2e test setup developers can use the same environment variable for both Kaniko e2e test and GCS taskrun test. To create a service account usable in the e2e tests:
 
-```shell
+```bash
 PROJECT_ID=your-gcp-project
 ACCOUNT_NAME=service-account-name
+# gcloud configure project
 gcloud config set project $PROJECT_ID
 
 # create the service account

--- a/test/gcs_taskrun_test.go
+++ b/test/gcs_taskrun_test.go
@@ -1,0 +1,138 @@
+// +build e2e
+
+/*
+Copyright 2018 Knative Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/knative/build-pipeline/test/builder"
+	knativetest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestStorageTaskRun is an integration test that will verify GCS input resource runtime contract
+// - adds volumes with expected name
+// - places files in expected place
+
+func TestStorageTaskRun(t *testing.T) {
+	configFile := os.Getenv("KANIKO_SECRET_CONFIG_FILE")
+	if configFile == "" {
+		t.Skip("KANIKO_SECRET_CONFIG_FILE variable is not set.")
+	}
+	logger := logging.GetContextLogger(t.Name())
+
+	c, namespace := setup(t, logger)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
+
+	authSec := createGCSSecret(t, logger, namespace, configFile)
+	if _, err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Create(authSec); err != nil {
+		t.Fatalf("Failed to create secret %s", err)
+	}
+
+	resName := "gcs-resource"
+	if _, err := c.PipelineResourceClient.Create(getResources(namespace, resName, authSec.Name, filepath.Base(configFile))); err != nil {
+		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", resName, err)
+	}
+
+	taskRunName := "gcs-taskrun"
+	logger.Infof("Creating Task and TaskRun %s in namespace %s", taskRunName, namespace)
+
+	if _, err := c.TaskClient.Create(getGCSStorageTask(namespace, authSec.Name, filepath.Base(configFile))); err != nil {
+		t.Fatalf("Failed to create Task gcs-file : %s", err)
+	}
+
+	if _, err := c.TaskRunClient.Create(getGCSTaskRun(namespace, taskRunName, resName)); err != nil {
+		t.Fatalf("Failed to create TaskRun %s: %s", taskRunName, err)
+	}
+
+	logger.Infof("Waiting for TaskRun %s in namespace %s to complete", taskRunName, namespace)
+
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", taskRunName, err)
+	}
+	logger.Infof("TaskRun %s succeeded", taskRunName)
+}
+
+func getGCSStorageTask(namespace, secretName, secretKey string) *v1alpha1.Task {
+	return tb.Task("gcs-file", namespace, tb.TaskSpec(
+		tb.TaskInputs(tb.InputsResource("gcsbucket", v1alpha1.PipelineResourceTypeStorage,
+			tb.ResourceTargetPath("gcs-workspace"),
+		)),
+		tb.Step("read-gcs-bucket", "ubuntu", tb.Command("/bin/bash"),
+			tb.Args("-c", "ls -la /workspace/gcs-workspace/rules_docker-master.zip"),
+		),
+		tb.Step("read-secret-env", "ubuntu", tb.Command("/bin/bash"),
+			tb.Args("-c", "ls -la $CREDENTIALS"),
+			tb.VolumeMount(corev1.VolumeMount{
+				Name: fmt.Sprintf("volume-gcs-resource-%s", secretName), // this build should have volume with
+				// name volume-(resource_name)-(secret_name) because of storage resource(gcs)
+				MountPath: fmt.Sprintf("/var/secret/%s", secretName),
+			}),
+			tb.EnvVar("CREDENTIALS", fmt.Sprintf("/var/secret/%s/%s", secretName, secretKey)),
+		),
+	))
+}
+
+func getGCSTaskRun(namespace, name, resName string) *v1alpha1.TaskRun {
+	return tb.TaskRun(name, namespace,
+		tb.TaskRunSpec(tb.TaskRunTaskRef("gcs-file"),
+			tb.TaskRunInputs(
+				tb.TaskRunInputsResource("gcsbucket", tb.ResourceBindingRef(resName)),
+			)))
+}
+
+func getResources(namespace, name, secretName, secretKey string) *v1alpha1.PipelineResource {
+	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeStorage,
+		tb.PipelineResourceSpecParam("location", "gs://build-crd-tests/rules_docker-master.zip"),
+		tb.PipelineResourceSpecParam("type", "gcs"),
+		tb.PipelineResourceSpecSecretParam("GOOGLE_APPLICATION_CREDENTIALS", secretName, secretKey),
+	))
+}
+
+func createGCSSecret(t *testing.T, logger *logging.BaseLogger, namespace, authFilePath string) *corev1.Secret {
+	t.Helper()
+
+	f, err := ioutil.ReadFile(authFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read json key file %s at path %s", err, authFilePath)
+	}
+
+	data := map[string][]byte{filepath.Base(authFilePath): f}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "auth-secret",
+		},
+		Data: data,
+	}
+}
+
+type GCPProject struct {
+	GCPconfig `json:"core"`
+}
+type GCPconfig struct {
+	Name string `json:"project"`
+}


### PR DESCRIPTION
Fixes https://github.com/knative/build-pipeline/issues/372

what is the bug: `gsutil` previosuly supported authentication using environment
variable(GOOGLE_APPLICATION_CREDENTIALS). Build pipeline gcs storage resource relied on this
feature to provide access for private gcs buckets. In recent version of `gsutil` there is a bug which did not recognize env variable.(thanks to @mgreau for reporting)

how is it fixed: authentication method is updated to be more concrete method using
`gcloud auth` command. This PR does not change user contract to
authentication but only implementation on how `gsutil` authentication is done behind the screen.

Test: 
- e2e test pipelinerun test is updated not to have gcs input resource as `gcloud auth` command requires valid service account json(in new authentication method). 
- New e2e test is added to replace old test coverage and in this test required resources like gcloud service account is created for test purpose and cleaned up on exit.
This test checks whether testing envirnonment has gcloud project config set and if not test will be skipped.

cc @bobcatfish @mgreau