### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun/config"

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/knative/build/pkg/apis/build/v1alpha1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
