### PR TITLE
Update resource path (again)

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -110,7 +110,7 @@ func AddInputResource(
 					build.Spec.Sources = append(build.Spec.Sources, buildv1alpha1.SourceSpec{
 						Git:        gitSourceSpec,
 						TargetPath: input.TargetPath,
-						Name:       gitResource.Name,
+						Name:       input.Name,
 					})
 				}
 			case v1alpha1.PipelineResourceTypeCluster:
@@ -173,7 +173,7 @@ func addClusterBuildStep(build *buildv1alpha1.Build, clusterResource *v1alpha1.C
 }
 
 func addStorageFetchStep(build *buildv1alpha1.Build, storageResource v1alpha1.PipelineStorageResourceInterface, destPath string) error {
-	var destDirectory = workspaceDir
+	var destDirectory = filepath.Join(workspaceDir, storageResource.GetName())
 	if destPath != "" {
 		destDirectory = filepath.Join(workspaceDir, destPath)
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -118,7 +118,7 @@ func gitToContainer(source v1alpha1.SourceSpec, index int) (*corev1.Container, e
 	}
 
 	if source.TargetPath != "" {
-		args = append(args, []string{"-path", filepath.Join(source.Name, source.TargetPath)}...)
+		args = append(args, []string{"-path", source.TargetPath}...)
 	} else {
 		args = append(args, []string{"-path", source.Name}...)
 	}
@@ -150,7 +150,7 @@ func gcsToContainer(source v1alpha1.SourceSpec, index int) (*corev1.Container, e
 	args := []string{"--type", string(gcs.Type), "--location", gcs.Location}
 	// dest_dir is the destination directory for GCS files to be copies"
 	if source.TargetPath != "" {
-		args = append(args, "--dest_dir", filepath.Join(workspaceDir, source.Name, source.TargetPath))
+		args = append(args, "--dest_dir", filepath.Join(workspaceDir, source.TargetPath))
 	} else {
 		args = append(args, "--dest_dir", filepath.Join(workspaceDir, source.Name))
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -371,7 +371,7 @@ func TestMakePod(t *testing.T) {
 			}, {
 				Name:         initContainerPrefix + gcsSource + "-gcs-foo-bar",
 				Image:        *gcsFetcherImage,
-				Args:         []string{"--type", "Manifest", "--location", "gs://foo/bar", "--dest_dir", "/workspace/gcs-foo-bar/path/foo"},
+				Args:         []string{"--type", "Manifest", "--location", "gs://foo/bar", "--dest_dir", "/workspace/path/foo"},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts, // without subpath
 				WorkingDir:   workspaceDir,

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -264,7 +264,7 @@ func TestReconcile(t *testing.T) {
 		name:    "params",
 		taskRun: taskRunTemplating,
 		wantBuildSpec: tb.BuildSpec(
-			tb.BuildSource("git-resource", tb.BuildSourceGit("https://foo.git", "master")),
+			tb.BuildSource("workspace", tb.BuildSourceGit("https://foo.git", "master")),
 			entrypointCopyStep,
 			tb.BuildStep("mycontainer", "myimage", tb.Command(entrypointLocation),
 				tb.EnvVar("ENTRYPOINT_OPTIONS", `{"args":["/mycmd","--my-arg=foo","--my-arg-with-default=bar","--my-arg-with-default2=thedefault","--my-additional-arg=gcr.io/kristoff/sven"],"process_log":"/tools/process-log.txt","marker_file":"/tools/marker-file.txt"}`),
@@ -307,7 +307,7 @@ func TestReconcile(t *testing.T) {
 		name:    "taskrun-with-taskspec",
 		taskRun: taskRunWithTaskSpec,
 		wantBuildSpec: tb.BuildSpec(
-			tb.BuildSource("git-resource", tb.BuildSourceGit("https://foo.git", "master")),
+			tb.BuildSource("workspace", tb.BuildSourceGit("https://foo.git", "master")),
 			entrypointCopyStep,
 			tb.BuildStep("mycontainer", "myimage", tb.Command(entrypointLocation),
 				tb.EnvVar("ENTRYPOINT_OPTIONS", `{"args":["/mycmd","--my-arg=foo"],"process_log":"/tools/process-log.txt","marker_file":"/tools/marker-file.txt"}`),

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -88,14 +88,14 @@ func createSecret(c *knativetest.KubeClient, namespace string) (bool, error) {
 
 func getTask(repo, namespace string, withSecretConfig bool) *v1alpha1.Task {
 	taskSpecOps := []tb.TaskSpecOp{
-		tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
+		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskTimeout(2 * time.Minute),
 	}
 	stepOps := []tb.ContainerOp{
 		tb.Args(
-			"--dockerfile=/workspace/go-example-git/Dockerfile",
+			"--dockerfile=/workspace/gitsource/Dockerfile",
 			fmt.Sprintf("--destination=%s", repo),
-			"--context=/workspace/go-example-git",
+			"--context=/workspace/gitsource",
 		),
 	}
 	if withSecretConfig {
@@ -118,7 +118,7 @@ func getTask(repo, namespace string, withSecretConfig bool) *v1alpha1.Task {
 func getTaskRun(namespace string) *v1alpha1.TaskRun {
 	return tb.TaskRun(kanikoTaskRunName, namespace, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(kanikoTaskName),
-		tb.TaskRunInputs(tb.TaskRunInputsResource("workspace", tb.ResourceBindingRef(kanikoResourceName))),
+		tb.TaskRunInputs(tb.TaskRunInputsResource("gitsource", tb.ResourceBindingRef(kanikoResourceName))),
 	))
 }
 


### PR DESCRIPTION
- In #393 PR to be resource is placed under path `workspace/resource_name` but there is a use case where a resource can be used by a task multiple times as source with duplicate names. 

In the following example  `testsource`, `sourcecode` could point to same git resource. So it made sense to have path as `/workspace/task_resource_name`

```
kind: Task
metadata:
  name: build-push
spec:
  inputs:
    resources:
    - name: testsourcecode
      type: git
   - name: sourcecode
      type: git
```
- Add more unit test to have more coverage for this use case.
- Enable helm deploy task in this PR (#393 PR disabled it as there is
cyclic dependency)

Sorry for 2 PRs to do this work. 

cc @bobcatfish @pivotal-nader-ziada 