### PR TITLE
Only copy output resource to PVC for storage/git output

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -763,3 +763,29 @@ func Test_InValid_OutputResources(t *testing.T) {
 		})
 	}
 }
+
+func Test_AllowedOutputResource(t *testing.T) {
+	for _, c := range []struct {
+		desc      	    string
+		resourceType    v1alpha1.PipelineResourceType
+		expectedAllowed bool
+	}{{
+		desc: "storage type is allowed",
+		resourceType: v1alpha1.PipelineResourceTypeStorage,
+		expectedAllowed: true,
+	}, {
+		desc: "git type is allowed",
+		resourceType: v1alpha1.PipelineResourceTypeGit,
+		expectedAllowed: true,
+	}, {
+		desc: "anything else is not allowed",
+		resourceType: "fooType",
+		expectedAllowed: false,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			if c.expectedAllowed != allowedOutputResources[c.resourceType] {
+				t.Fatalf("Test AllowedOutputResource %s expected %t but got %t", c.desc, c.expectedAllowed, allowedOutputResources[c.resourceType])
+			}
+		})
+	}
+}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -85,6 +85,14 @@ func outputResourcesetUp() {
 				FieldName:  "STORAGE_CREDS",
 			}},
 		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "source-image",
+			Namespace: "marshmallow",
+		},
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: "image",
+		},
 	}}
 
 	for _, r := range rs {
@@ -549,6 +557,45 @@ func Test_Valid_OutputResources(t *testing.T) {
 				Secret: &corev1.SecretVolumeSource{SecretName: "sname"},
 			},
 		}},
+	}, {
+		name: "image resource as output",
+		desc: "image resource defined only in output",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-only-output-step",
+				Namespace: "marshmallow",
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind: "PipelineRun",
+					Name: "pipelinerun",
+				}},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						Name: "source-workspace",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "source-image",
+						},
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						Name: "source-workspace",
+						Type: "image",
+					}},
+				},
+			},
+		},
+		wantSteps: nil,
+		build: build(),
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			outputResourcesetUp()


### PR DESCRIPTION
At the moment the output_resource module unconditionally adds a
copy step for every output resource in the taskrun.
However not every output resource will generate content to be
copied. Limit the copy to Storage and Git outoputs for now.

This is meant as a hotfix for bug #401 until an implementation
of the image output resource is available via #216. Until
image resource output is implemented, any consumer won't
have guarantee that the image has been actually built and pushed,
and won't know the hash of the created image.