### PR TITLE
Update deps with lru cache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -819,6 +819,7 @@
     "github.com/google/go-containerregistry/pkg/v1/partial",
     "github.com/google/go-containerregistry/pkg/v1/remote",
     "github.com/google/go-containerregistry/pkg/v1/types",
+    "github.com/hashicorp/golang-lru",
     "github.com/knative/build/pkg/apis/build/v1alpha1",
     "github.com/knative/build/pkg/system",
     "github.com/knative/caching/pkg/apis/caching",


### PR DESCRIPTION
Missing dep, probably after lru cache was implemented in
https://github.com/knative/build-pipeline/pull/350