### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
@@ -48,8 +48,8 @@ func TestCancelPipelineRun(t *testing.T) {
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			&resources.ResolvedPipelineRunTask{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
-			&resources.ResolvedPipelineRunTask{TaskRunName: "t2"},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			{TaskRunName: "t2"},
 		},
 		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo")},
 	}, {
@@ -60,8 +60,8 @@ func TestCancelPipelineRun(t *testing.T) {
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			&resources.ResolvedPipelineRunTask{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
-			&resources.ResolvedPipelineRunTask{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", "foo")},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", "foo")},
 		},
 		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo"), tb.TaskRun("t2", "foo")},
 	}}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -595,7 +595,7 @@ func Test_Valid_OutputResources(t *testing.T) {
 			},
 		},
 		wantSteps: nil,
-		build: build(),
+		build:     build(),
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			outputResourcesetUp()
@@ -766,20 +766,20 @@ func Test_InValid_OutputResources(t *testing.T) {
 
 func Test_AllowedOutputResource(t *testing.T) {
 	for _, c := range []struct {
-		desc      	    string
+		desc            string
 		resourceType    v1alpha1.PipelineResourceType
 		expectedAllowed bool
 	}{{
-		desc: "storage type is allowed",
-		resourceType: v1alpha1.PipelineResourceTypeStorage,
+		desc:            "storage type is allowed",
+		resourceType:    v1alpha1.PipelineResourceTypeStorage,
 		expectedAllowed: true,
 	}, {
-		desc: "git type is allowed",
-		resourceType: v1alpha1.PipelineResourceTypeGit,
+		desc:            "git type is allowed",
+		resourceType:    v1alpha1.PipelineResourceTypeGit,
 		expectedAllowed: true,
 	}, {
-		desc: "anything else is not allowed",
-		resourceType: "fooType",
+		desc:            "anything else is not allowed",
+		resourceType:    "fooType",
 		expectedAllowed: false,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
