### PR TITLE
Only copy output of resources when possible

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -197,10 +197,3 @@ func addStoreUploadStep(build *buildv1alpha1.Build,
 	build.Spec.Steps = append(build.Spec.Steps, buildSteps...)
 	return nil
 }
-
-// allowedOutputResource checks if an output resource type produces
-// an output that should be copied to the PVC
-func allowedOutputResource(resourceType v1alpha1.PipelineResourceType) bool {
-
-	return allowedOutputResources[resourceType]
-}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -784,7 +784,7 @@ func Test_AllowedOutputResource(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			if c.expectedAllowed != allowedOutputResources[c.resourceType] {
-				t.Fatalf("Test AllowedOutputResource %s expected %t but got %t", c.desc, c.expectedAllowed, allowedOutputResources[c.resourceType])
+				t.Fatalf("Test allowedOutputResource %s expected %t but got %t", c.desc, c.expectedAllowed, allowedOutputResources[c.resourceType])
 			}
 		})
 	}


### PR DESCRIPTION
Input resources may copy output from output resources from previous
tasks - do that only if the resources is an allowed type.

This is a follow-up on the work started in #414 to fix issue #401 .