### PR TITLE
Format markdown

### DIFF
--- a/docs/Concepts.md
+++ b/docs/Concepts.md
@@ -22,8 +22,8 @@ High level details of this design:
   [Pipelines](#pipeline); they are highly cohesive and loosely coupled
 - [Tasks](#task) can depend on artifacts, output and parameters created by other
   tasks.
-- [PipelineResources](#pipelineresources) are the artifacts used as inputs and outputs
-  of Tasks.
+- [PipelineResources](#pipelineresources) are the artifacts used as inputs and
+  outputs of Tasks.
 
 ## Building Blocks of Pipeline CRDs
 
@@ -41,8 +41,9 @@ Below diagram lists the main custom resources created by Pipeline CRDs:
 
 ### Task
 
-A `Task` is a collection of sequential steps you would want to run as part of your
-continuous integration flow. A task will run inside a container on your cluster.
+A `Task` is a collection of sequential steps you would want to run as part of
+your continuous integration flow. A task will run inside a container on your
+cluster.
 
 A `Task` declares:
 
@@ -52,8 +53,8 @@ A `Task` declares:
 
 #### Inputs
 
-Declare the inputs the `Task` needs. Every `Task` input resource should provide name
-and type (like git, image).
+Declare the inputs the `Task` needs. Every `Task` input resource should provide
+name and type (like git, image).
 
 #### Outputs
 
@@ -137,7 +138,8 @@ For example:
   deployed in a cluster.
 - A Task's output can be a jar file to be uploaded to a storage bucket.
 
-Read more on PipelineResources and their types [here](./using.md#creating-pipelineresources).
+Read more on PipelineResources and their types
+[here](./using.md#creating-pipelineresources).
 
 `PipelineResources` in a Pipeline are the set of objects that are going to be
 used as inputs and outputs of a `Task`.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -3,11 +3,12 @@
 Welcome to the Pipeline tutorial!
 
 This tutorial will walk you through creating and running some simple
-[`Tasks`](concepts.md#task), [`Pipelines`](concepts.md#pipeline) and running them
-by creating [`TaskRuns`](concepts.md#taskruns) and [`PipelineRuns`](concepts.md#pipelineruns).
+[`Tasks`](concepts.md#task), [`Pipelines`](concepts.md#pipeline) and running
+them by creating [`TaskRuns`](concepts.md#taskruns) and
+[`PipelineRuns`](concepts.md#pipelineruns).
 
-* [Creating a hello world `Task`](#tasks)
-* [Creating a hello world `Pipeline`](#pipelines)
+- [Creating a hello world `Task`](#tasks)
+- [Creating a hello world `Pipeline`](#pipelines)
 
 For more details on using `Pipelines`, see [our usage docs](usage.md).
 
@@ -120,10 +121,11 @@ repository and build a Docker image from it.
 
 [`PipelinesResources`](concepts.md#pipelineresources) are used to define the
 artifacts that can be passed in and out of a task. There are a few system
-defined resource types ready to use, and the following are two examples of
-the resources commonly needed.
+defined resource types ready to use, and the following are two examples of the
+resources commonly needed.
 
-The [`git` resource](using.md#git-resource) represents a git repository with a specific revision:
+The [`git` resource](using.md#git-resource) represents a git repository with a
+specific revision:
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -139,7 +141,8 @@ spec:
       value: https://github.com/GoogleContainerTools/skaffold
 ```
 
-The [`image` resource](using.md#image-resource) represents theimage to be built by the task:
+The [`image` resource](using.md#image-resource) represents theimage to be built
+by the task:
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -153,8 +156,8 @@ spec:
       value: gcr.io/<use your project>/leeroy-web
 ```
 
-The following is a `Task` with inputs and outputs. The input resource is a GitHub
-repository and the output is the image produced from that source. The
+The following is a `Task` with inputs and outputs. The input resource is a
+GitHub repository and the output is the image produced from that source. The
 args of the task command support templating so that the definition of task is
 constant and the value of parameters can change in runtime.
 
@@ -328,9 +331,9 @@ resource definition.
 # Pipeline
 
 A [`Pipeline`](concepts.md#pipelines) defines a list of tasks to execute in
-order, while also indicating if any outputs should be used as inputs
-of a following task by using [the `providedBy` field](using.md#providedby).
-The same templating you used in tasks is also available in pipeline.
+order, while also indicating if any outputs should be used as inputs of a
+following task by using [the `providedBy` field](using.md#providedby). The same
+templating you used in tasks is also available in pipeline.
 
 For example:
 
@@ -341,10 +344,10 @@ metadata:
   name: tutorial-pipeline
 spec:
   resources:
-  - name: source-repo
-    type: git
-  - name: web-image
-    type: image
+    - name: source-repo
+      type: git
+    - name: web-image
+      type: image
   tasks:
     - name: build-skaffold-web
       taskRef:
@@ -356,22 +359,22 @@ spec:
           value: /workspace/examples/microservices/leeroy-web
       resources:
         inputs:
-        - name: workspace
-          resource: source-repo
+          - name: workspace
+            resource: source-repo
         outputs:
-        - name: image
-          resource: web-image
+          - name: image
+            resource: web-image
     - name: deploy-web
       taskRef:
         name: demo-deploy-kubectl
       resources:
         inputs:
-        - name: workspace
-          resource: source-repo
-        - name: image
-          resource: web-image
-          providedBy:
-          - build-skaffold-web
+          - name: workspace
+            resource: source-repo
+          - name: image
+            resource: web-image
+            providedBy:
+              - build-skaffold-web
       params:
         - name: path
           value: /workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
@@ -381,8 +384,8 @@ spec:
           value: "spec.template.spec.containers[0].image"
 ```
 
-The above `Pipeline` is referencing a `Task` called `deploy-using-kubectl` which can be found
-here:
+The above `Pipeline` is referencing a `Task` called `deploy-using-kubectl` which
+can be found here:
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -426,7 +429,8 @@ spec:
         - "${inputs.params.path}"
 ```
 
-To run the `Pipeline`, create a [`PipelineRun`](concepts.md#pipelinerun) as follows:
+To run the `Pipeline`, create a [`PipelineRun`](concepts.md#pipelinerun) as
+follows:
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -439,16 +443,16 @@ spec:
   trigger:
     type: manual
   resources:
-  - name: source-repo
-    resourceRef:
-      name: skaffold-git
-  - name: web-image
-    resourceRef:
-      name: skaffold-image-leeroy-web
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web
 ```
 
-The `PipelineRun` will create the `TaskRuns` corresponding to each `Task` and collect
-the results.
+The `PipelineRun` will create the `TaskRuns` corresponding to each `Task` and
+collect the results.
 
 To apply the yaml files use the following command, you will need to apply the
 `deploy-task` if you want to run the Pipeline.
@@ -482,14 +486,14 @@ spec:
   pipelineRef:
     name: tutorial-pipeline
   resources:
-  - name: source-repo
-    paths: null
-    resourceRef:
-      name: skaffold-git
-  - name: web-image
-    paths: null
-    resourceRef:
-      name: skaffold-image-leeroy-web
+    - name: source-repo
+      paths: null
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      paths: null
+      resourceRef:
+        name: skaffold-image-leeroy-web
   serviceAccount: ""
   trigger:
     type: manual

--- a/docs/using.md
+++ b/docs/using.md
@@ -36,10 +36,10 @@ For example:
 ```yaml
 spec:
   resources:
-  - name: my-repo
-    type: git
-  - name: my-image
-    type: image
+    - name: my-repo
+      type: git
+    - name: my-image
+      type: image
 ```
 
 These `PipelineResources` can then be provided to `Task`s in the `Pipeline` as
@@ -49,30 +49,30 @@ inputs and outputs, for example:
 spec:
   #...
   tasks:
-  - name: build-the-image
-    taskRef:
-      name: build-push
-    resources:
-      inputs:
-      - name: workspace
-        resource: my-repo
-      outputs:
-      - name: image
-        resource: my-image
+    - name: build-the-image
+      taskRef:
+        name: build-push
+      resources:
+        inputs:
+          - name: workspace
+            resource: my-repo
+        outputs:
+          - name: image
+            resource: my-image
 ```
 
 ### ProvidedBy
 
-Sometimes you will have `Tasks` that need to take as input the output of a previous
-`Task`, for example, an image built by a previous `Task`.
+Sometimes you will have `Tasks` that need to take as input the output of a
+previous `Task`, for example, an image built by a previous `Task`.
 
 Express this dependency by adding `providedBy` on `Resources` that your `Tasks`
 need.
 
 - The (optional) `providedBy` key on an `input source` defines a set of previous
   `PipelineTasks` (i.e. the named instance of a `Task`) in the `Pipeline`
-- When the `providedBy` key is specified on an input source, the version of
-  the resource that is provided by the defined list of tasks is used
+- When the `providedBy` key is specified on an input source, the version of the
+  resource that is provided by the defined list of tasks is used
 - The `providedBy` can support fan in and fan out
 - The name of the `PipelineResource` must correspond to a `PipelineResource`
   from the `Task` that the referenced `PipelineTask` provides as an output
@@ -85,8 +85,8 @@ For example see this `Pipeline` spec:
     name: build-push
   resources:
     outputs:
-    - name: image
-      resource: my-image
+      - name: image
+        resource: my-image
 - name: deploy-app
   taskRef:
     name: deploy-kubectl
@@ -97,9 +97,9 @@ For example see this `Pipeline` spec:
           - build-app
 ```
 
-The resource `my-image` is expected to be provided to the `deploy-app` `Task` from
-the `build-app` `Task`. This means that the `PipelineResource` `my-image` must also
-be declared as an output of `build-app`.
+The resource `my-image` is expected to be provided to the `deploy-app` `Task`
+from the `build-app` `Task`. This means that the `PipelineResource` `my-image`
+must also be declared as an output of `build-app`.
 
 For implementation details, see [the developer docs](docs/developers/README.md).
 
@@ -184,9 +184,9 @@ configure that by edit the `image`'s value in a configmap named
 ### Resource sharing between tasks
 
 Pipeline `Tasks` are allowed to pass resources from previous `Tasks` via the
-[`providedBy`](#providedby) field. This feature is implemented using
-Persistent Volume Claims under the hood but however has an implication
-that tasks cannot have any volume mounted under path `/pvc`.
+[`providedBy`](#providedby) field. This feature is implemented using Persistent
+Volume Claims under the hood but however has an implication that tasks cannot
+have any volume mounted under path `/pvc`.
 
 ### Outputs
 
@@ -252,8 +252,8 @@ steps:
 
 Tasks can opitionally provide `targetPath` to initialize resource in specific
 directory. If `targetPath` is set then resource will be initialized under
-`/workspace/targetPath`. If `targetPath` is not specified then resource will
-be initialized under `/workspace`. Following example demonstrates how git input
+`/workspace/targetPath`. If `targetPath` is not specified then resource will be
+initialized under `/workspace`. Following example demonstrates how git input
 repository could be initialized in `$GOPATH` to run tests:
 
 ```yaml
@@ -338,9 +338,10 @@ In order to run a Pipeline, you will need to provide:
 2. The `PipelineResources` to use with this Pipeline.
 
 On its own, a `Pipeline` declares what `Tasks` to run, and dependencies between
-`Task` inputs and outputs via [`providedBy`](#providedby). When running a `Pipeline`, you
-will need to specify the `PipelineResources` to use with it. One `Pipeline` may
-need to be run with different `PipelineResources` in cases such as:
+`Task` inputs and outputs via [`providedBy`](#providedby). When running a
+`Pipeline`, you will need to specify the `PipelineResources` to use with it. One
+`Pipeline` may need to be run with different `PipelineResources` in cases such
+as:
 
 - When triggering the run of a `Pipeline` against a pull request, the triggering
   system must specify the commitish of a git `PipelineResource` to use
@@ -355,15 +356,15 @@ in the `PipelineRun` spec, for example:
 ```yaml
 spec:
   resources:
-  - name: source-repo
-    resourceRef:
-      name: skaffold-git
-  - name: web-image
-    resourceRef:
-      name: skaffold-image-leeroy-web
-  - name: app-image
-    resourceRef:
-      name: skaffold-image-leeroy-app
+    - name: source-repo
+      resourceRef:
+        name: skaffold-git
+    - name: web-image
+      resourceRef:
+        name: skaffold-image-leeroy-web
+    - name: app-image
+      resourceRef:
+        name: skaffold-image-leeroy-app
 ```
 
 Creation of a `PipelineRun` will trigger the creation of
@@ -521,11 +522,11 @@ spec:
 ### Using custom paths
 
 When specifying input and output `PipelineResources`, you can optionally specify
-`paths` for each resource. `paths` will be used by `TaskRun` as the resource's new source paths
-i.e., copy the resource from specified list of paths. `TaskRun` expects the
-folder and contents to be already present in specified paths. `paths` feature
-could be used to provide extra files or altered version of existing resource
-before execution of steps.
+`paths` for each resource. `paths` will be used by `TaskRun` as the resource's
+new source paths i.e., copy the resource from specified list of paths. `TaskRun`
+expects the folder and contents to be already present in specified paths.
+`paths` feature could be used to provide extra files or altered version of
+existing resource before execution of steps.
 
 Output resource includes name and reference to pipeline resource and optionally
 `paths`. `paths` will be used by `TaskRun` as the resource's new destination

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,10 +28,10 @@ kubectl apply -f examples/run/output-pipeline-run.yaml
 from [the Skaffold repo](https://github.com/GoogleContainerTools/skaffold) and
 deploys them to the repo currently running the Pipeline CRD.
 
-It does this using the k8s `Deployment` in the skaffold repos's existing yaml files,
-so at the moment there is no guarantee that the image that are built and pushed are the ones that
-are deployed (that would require using the digest of the built image, see
-https://github.com/knative/build-pipeline/issues/216).
+It does this using the k8s `Deployment` in the skaffold repos's existing yaml
+files, so at the moment there is no guarantee that the image that are built and
+pushed are the ones that are deployed (that would require using the digest of
+the built image, see https://github.com/knative/build-pipeline/issues/216).
 
 To run this yourself, you will need to change the values of
 `gcr.io/christiewilson-catfactory` to a registry you can push to from inside


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`