### PR TITLE
Allow taskrun to embed resource spec in inputs & outputs

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -422,12 +422,57 @@ spec:
 
 ## Running a Task
 
-1. To run a `Task`, create a new `TaskRun` which defines all inputs, outputs
-   that the `Task` needs to run.
-2. The `TaskRun` will also serve as a record of the history of the invocations
-   of the `Task`.
-3. Another way of running a Task is embedding the TaskSpec in the taskRun yaml
-   as shown in the following example
+### TaskRun with references
+
+To run a `Task`, create a new `TaskRun` which defines all inputs, outputs that the `Task` needs to run. Below is an example where Task `read-task` is run by creating `read-repo-run`. Task `read-task` has git input resource and TaskRun `read-repo-run` includes reference to `go-example-git`.
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: read-repo-run
+spec:
+  taskRef:
+    name: read-task
+  trigger:
+    type: manual
+  inputs:
+    resources:
+      - name: workspace
+        resourceRef:
+          name: go-example-git
+---
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: go-example-git
+spec:
+  type: git
+  params:
+  - name: url
+    value: https://github.com/pivotal-nader-ziada/gohelloworld
+---
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: Task
+metadata:
+  name: read-task
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+  steps:
+  - name: readme
+    image: ubuntu
+    command:
+    - /bin/bash
+    args:
+    - "cat README.md"
+```
+
+### Taskrun with embedded definitions
+
+Another way of running a Task is embedding the TaskSpec in the taskRun yaml. TaskRun resource can include either Task reference or TaskSpec but not both. Below is an example where `build-push-task-run-2` includes `TaskSpec` and no reference to Task.
 
 ```yaml
 apiVersion: pipeline.knative.dev/v1alpha1
@@ -466,9 +511,31 @@ spec:
           - --destination=gcr.io/my-project/gohelloworld
 ```
 
-If the TaskSpec is provided, TaskRef is not allowed.
+Input and output resources can also be embedded without creating Pipeline Resources. TaskRun resource can include either Pipeline Resource reference or Pipeline Resource Spec but not both. Below is an example where Git Pipeline Resource Spec is provided as input for TaskRun `read-repo`.
 
-See [the example TaskRun](../examples/runs/task-run.yaml).
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: read-repo
+spec:
+  taskRef:
+    name: read-task
+  trigger:
+    type: manual
+  inputs:
+    resources:
+      - name: workspace
+        resourceSpec:
+          type: git
+          params:
+            - name: url
+              value: https://github.com/pivotal-nader-ziada/gohelloworld
+```
+
+**Note**: TaskRun can embed both TaskSpec and resource spec at the same time. See [example](../examples/run/task-run-resource-spec.yaml) TaskRun. The `TaskRun` will also serve as a record of the history of the invocations of the `Task`.
+
+For more sample taskruns check out [example folder](../examples/run/).
 
 ### Using a ServiceAccount
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,9 @@ kubectl apply -f examples/run/pipeline-run.yaml
 
 # To invoke the Pipeline that links outputs
 kubectl apply -f examples/run/output-pipeline-run.yaml
+
+# To invoke the TaskRun with embedded Resource spec and task Spec
+kubectl apply -f examples/run/task-run-resource-spec.yaml
 ```
 
 ## Example Pipelines
@@ -62,6 +65,7 @@ The [run](./run/) directory contains an example
   the `build-push` task
 - [pipeline-run.yaml](./run/pipeline-run.yaml) invokes
   [the example pipeline](#example-pipeline)
+- [embed-resource-spec.yaml](./run/task-run-resource-spec.yaml) shows an example how to create TaskRun with embedded Task spec and resource spec.
 
 ### Pipeline with outputs
 

--- a/examples/run/task-run-resource-spec.yaml
+++ b/examples/run/task-run-resource-spec.yaml
@@ -1,0 +1,28 @@
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: read-file
+spec:
+  taskSpec:
+   inputs:
+    resources:
+    - name: skaffold
+      type: git
+      targetPath: skaffold
+    steps:
+    - name: read
+      image: ubuntu
+      command: ["/bin/bash"]
+      args: ['-c', 'cat /workspace/skaffold/README.md'] # tests that resource spec and task spec can be defined in taskrun
+  trigger:
+    type: manual
+  inputs:
+    resources:
+    - name: workspace
+      resourceSpec:
+        type: git
+        params:
+          - name: revision
+            value: master
+          - name: url
+            value: https://github.com/GoogleContainerTools/skaffold

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -167,6 +167,17 @@ func TestResourceValidation_Invalid(t *testing.T) {
 				},
 			},
 			want: apis.ErrMissingField("spec.params.location"),
+		}, {
+			name: "invalid resoure type",
+			res: PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "invalid-resource",
+				},
+				Spec: PipelineResourceSpec{
+					Type: "not-supported",
+				},
+			},
+			want: apis.ErrInvalidValue("spec.type", "not-supported"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -132,8 +132,12 @@ type PipelineResourceBinding struct {
 // corresponds to a path on disk at which the Resource can be found (used when providing
 // the resource via mounted volume, overriding the default logic to fetch the Resource).
 type TaskResourceBinding struct {
-	Name        string              `json:"name"`
+	Name string `json:"name"`
+	// no more than one of the ResourceRef and ResourceSpec may be specified.
+	// +optional
 	ResourceRef PipelineResourceRef `json:"resourceRef"`
+	// +optional
+	ResourceSpec *PipelineResourceSpec `json:"resourceSpec"`
 	// +optional
 	Paths []string `json:"paths"`
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -73,17 +73,21 @@ func (ts *TaskRunSpec) Validate() *apis.FieldError {
 }
 
 func (i TaskRunInputs) Validate(path string) *apis.FieldError {
-	if err := checkForPipelineResourceDuplicates(i.Resources, fmt.Sprintf("%s.Resources.Name", path)); err != nil {
+	if err := validatePipelineResources(i.Resources, fmt.Sprintf("%s.Resources.Name", path)); err != nil {
 		return err
 	}
 	return validateParameters(i.Params)
 }
 
 func (o TaskRunOutputs) Validate(path string) *apis.FieldError {
-	return checkForPipelineResourceDuplicates(o.Resources, fmt.Sprintf("%s.Resources.Name", path))
+	return validatePipelineResources(o.Resources, fmt.Sprintf("%s.Resources.Name", path))
 }
 
-func checkForPipelineResourceDuplicates(resources []TaskResourceBinding, path string) *apis.FieldError {
+// validatePipelineResources validates that
+//	1. resource is not declared more than once
+//	2. if both resource reference and resource spec is defined at the same time
+//	3. at least resource ref or resource spec is defined
+func validatePipelineResources(resources []TaskResourceBinding, path string) *apis.FieldError {
 	encountered := map[string]struct{}{}
 	for _, r := range resources {
 		// We should provide only one binding for each resource required by the Task.
@@ -92,7 +96,19 @@ func checkForPipelineResourceDuplicates(resources []TaskResourceBinding, path st
 			return apis.ErrMultipleOneOf(path)
 		}
 		encountered[name] = struct{}{}
+		// Check that both resource ref and resource Spec are not present
+		if r.ResourceRef.Name != "" && r.ResourceSpec != nil {
+			return apis.ErrDisallowedFields(fmt.Sprintf("%s.ResourceRef", path), fmt.Sprintf("%s.ResourceSpec", path))
+		}
+		// Check that one of resource ref and resource Spec is present
+		if r.ResourceRef.Name == "" && r.ResourceSpec == nil {
+			return apis.ErrMissingField(fmt.Sprintf("%s.ResourceRef", path), fmt.Sprintf("%s.ResourceSpec", path))
+		}
+		if r.ResourceSpec != nil && r.ResourceSpec.Validate() != nil {
+			return r.ResourceSpec.Validate()
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -277,6 +277,39 @@ func TestInput_Invalidate(t *testing.T) {
 				}},
 			},
 			wantErr: apis.ErrMultipleOneOf("spec.inputs.params"),
+		}, {
+			name: "duplicate resource ref and resource spec",
+			inputs: TaskRunInputs{
+				Resources: []TaskResourceBinding{{
+					ResourceRef: PipelineResourceRef{
+						Name: "testresource",
+					},
+					ResourceSpec: &PipelineResourceSpec{
+						Type: PipelineResourceTypeGit,
+					},
+					Name: "resource-dup",
+				}},
+			},
+			wantErr: apis.ErrDisallowedFields("spec.Inputs.Resources.Name.ResourceRef", "spec.Inputs.Resources.Name.ResourceSpec"),
+		}, {
+			name: "invalid resource spec",
+			inputs: TaskRunInputs{
+				Resources: []TaskResourceBinding{{
+					ResourceSpec: &PipelineResourceSpec{
+						Type: "non-existent",
+					},
+					Name: "resource-inv",
+				}},
+			},
+			wantErr: apis.ErrInvalidValue("spec.type", "non-existent"),
+		}, {
+			name: "no resource ref and resource spec",
+			inputs: TaskRunInputs{
+				Resources: []TaskResourceBinding{{
+					Name: "resource",
+				}},
+			},
+			wantErr: apis.ErrMissingField("spec.Inputs.Resources.Name.ResourceRef", "spec.Inputs.Resources.Name.ResourceSpec"),
 		},
 	}
 	for _, ts := range tests {
@@ -324,6 +357,14 @@ func TestOutput_Invalidate(t *testing.T) {
 				}},
 			},
 			wantErr: apis.ErrMultipleOneOf("spec.Outputs.Resources.Name"),
+		}, {
+			name: "no output resource with resource spec nor resource ref",
+			outputs: TaskRunOutputs{
+				Resources: []TaskResourceBinding{{
+					Name: "workspace",
+				}},
+			},
+			wantErr: apis.ErrMissingField("spec.Outputs.Resources.Name.ResourceSpec", "spec.Outputs.Resources.Name.ResourceRef"),
 		},
 	}
 	for _, ts := range tests {

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -946,6 +946,15 @@ func (in *TaskResource) DeepCopy() *TaskResource {
 func (in *TaskResourceBinding) DeepCopyInto(out *TaskResourceBinding) {
 	*out = *in
 	out.ResourceRef = in.ResourceRef
+	if in.ResourceSpec != nil {
+		in, out := &in.ResourceSpec, &out.ResourceSpec
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(PipelineResourceSpec)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	if in.Paths != nil {
 		in, out := &in.Paths, &out.Paths
 		*out = make([]string, len(*in))

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -309,7 +309,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 
 	updateTaskRunsStatus(pr, pipelineState)
 
-	c.Logger.Infof("PipelineRun %s status is being set to %s", pr.Name, pr.Status)
+	c.Logger.Infof("PipelineRun %s status is being set to %s", pr.Name, pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -42,18 +42,13 @@ func ApplyParameters(b *buildv1alpha1.Build, tr *v1alpha1.TaskRun, defaults ...v
 	return ApplyReplacements(b, replacements)
 }
 
-// ResourceGetter is the interface used to retrieve resources which are references via a TaskRunResource.
-type ResourceGetter interface {
-	Get(string) (*v1alpha1.PipelineResource, error)
-}
-
 // ApplyResources applies the templating from values in resources which are referenced in b as subitems
 // of the replacementStr. It retrieves the referenced resources via the getter.
-func ApplyResources(b *buildv1alpha1.Build, resources []v1alpha1.TaskResourceBinding, getter ResourceGetter, replacementStr string) (*buildv1alpha1.Build, error) {
+func ApplyResources(b *buildv1alpha1.Build, resources []v1alpha1.TaskResourceBinding, getter GetResource, replacementStr string) (*buildv1alpha1.Build, error) {
 	replacements := map[string]string{}
 
 	for _, r := range resources {
-		pr, err := getter.Get(r.ResourceRef.Name)
+		pr, err := getResource(&r, getter)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -175,17 +175,15 @@ func (rg *rg) With(name string, pr *v1alpha1.PipelineResource) *rg {
 	return rg
 }
 
-func mockGetter() *rg {
-	return &rg{
-		resources: map[string]*v1alpha1.PipelineResource{},
-	}
-}
+var mockGetter = func(n string) (*v1alpha1.PipelineResource, error) { return &v1alpha1.PipelineResource{}, nil }
+var gitResourceGetter = func(n string) (*v1alpha1.PipelineResource, error) { return gitResource, nil }
+var imageResourceGetter = func(n string) (*v1alpha1.PipelineResource, error) { return imageResource, nil }
 
 func TestApplyResources(t *testing.T) {
 	type args struct {
 		b      *buildv1alpha1.Build
 		r      []v1alpha1.TaskResourceBinding
-		getter ResourceGetter
+		getter GetResource
 		rStr   string
 	}
 	tests := []struct {
@@ -199,7 +197,7 @@ func TestApplyResources(t *testing.T) {
 			args: args{
 				b:      simpleBuild,
 				r:      []v1alpha1.TaskResourceBinding{},
-				getter: mockGetter(),
+				getter: mockGetter,
 				rStr:   "inputs",
 			},
 			want: simpleBuild,
@@ -209,7 +207,7 @@ func TestApplyResources(t *testing.T) {
 			args: args{
 				b:      simpleBuild,
 				r:      inputs,
-				getter: mockGetter().With("git-resource", gitResource),
+				getter: gitResourceGetter,
 				rStr:   "inputs",
 			},
 			want: applyMutation(simpleBuild, func(b *buildv1alpha1.Build) {
@@ -221,7 +219,7 @@ func TestApplyResources(t *testing.T) {
 			args: args{
 				b:      simpleBuild,
 				r:      outputs,
-				getter: mockGetter().With("image-resource", imageResource),
+				getter: imageResourceGetter,
 				rStr:   "outputs",
 			},
 			want: applyMutation(simpleBuild, func(b *buildv1alpha1.Build) {
@@ -233,7 +231,7 @@ func TestApplyResources(t *testing.T) {
 			args: args{
 				b:      simpleBuild,
 				r:      inputs,
-				getter: mockGetter(),
+				getter: mockGetter,
 				rStr:   "inputs",
 			},
 			wantErr: true,

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -85,9 +85,9 @@ func AddOutputResources(
 			return fmt.Errorf("Failed to get bound resource: %s", err)
 		}
 
-		resource, err := pipelineResourceLister.PipelineResources(taskRun.Namespace).Get(boundResource.ResourceRef.Name)
+		resource, err := getResource(boundResource, pipelineResourceLister.PipelineResources(taskRun.Namespace).Get)
 		if err != nil {
-			return fmt.Errorf("Failed to get output pipeline Resource for task %q: %q", boundResource.ResourceRef.Name, taskName)
+			return fmt.Errorf("Failed to get output pipeline Resource for task %q resource %q; error: %s", taskName, boundResource, err.Error())
 		}
 
 		// if resource is declared in input then copy outputs to pvc
@@ -196,11 +196,4 @@ func addStoreUploadStep(build *buildv1alpha1.Build,
 	}
 	build.Spec.Steps = append(build.Spec.Steps, buildSteps...)
 	return nil
-}
-
-// allowedOutputResource checks if an output resource type produces
-// an output that should be copied to the PVC
-func allowedOutputResource(resourceType v1alpha1.PipelineResourceType) bool {
-
-	return allowedOutputResources[resourceType]
 }

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -636,6 +636,108 @@ func Test_InValid_OutputResources(t *testing.T) {
 		wantSteps []corev1.Container
 		wantErr   bool
 	}{{
+		desc: "git declared in both resource spec and resource ref",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-output-steps",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						Name: "source-workspace",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "source-git",
+						},
+						ResourceSpec: &v1alpha1.PipelineResourceSpec{
+							Type: v1alpha1.PipelineResourceTypeGit,
+						},
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						Name: "source-workspace",
+						Type: "git",
+					}},
+				},
+			},
+		},
+		wantErr: true,
+	}, {
+		desc: "git declared in output both in resource ref and spec",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-output-steps",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						Name: "source-workspace",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "source-git",
+						},
+						ResourceSpec: &v1alpha1.PipelineResourceSpec{
+							Type: v1alpha1.PipelineResourceTypeGit,
+						},
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						Name: "source-workspace",
+						Type: "git",
+					}},
+				},
+			},
+		},
+		wantErr: true,
+	}, {
+		desc: "git declared in neither resource ref and spec",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-output-steps",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						Name: "source-workspace",
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						Name: "source-workspace",
+						Type: "git",
+					}},
+				},
+			},
+		},
+		wantErr: true,
+	}, {
 		desc: "no outputs defined",
 		task: &v1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
@@ -758,7 +860,7 @@ func Test_InValid_OutputResources(t *testing.T) {
 			outputResourcesetUp()
 			err := AddOutputResources(build(), c.task.Name, &c.task.Spec, c.taskRun, outputpipelineResourceLister, logger)
 			if (err != nil) != c.wantErr {
-				t.Fatalf("Test AddOutputResourceSteps error %v ", c.desc)
+				t.Fatalf("Test AddOutputResourceSteps %v ; error: %s", c.desc, err)
 			}
 		})
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution.go
@@ -50,17 +50,21 @@ func ResolveTaskResources(ts *v1alpha1.TaskSpec, taskName string, inputs []v1alp
 	}
 
 	for _, r := range inputs {
-		rr, err := gr(r.ResourceRef.Name)
+		rr, err := getResource(&r, gr)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't retrieve referenced input PipelineResource %q: %s", r.ResourceRef.Name, err)
 		}
+
 		rtr.Inputs[r.Name] = rr
 	}
+
 	for _, r := range outputs {
-		rr, err := gr(r.ResourceRef.Name)
+		rr, err := getResource(&r, gr)
+
 		if err != nil {
 			return nil, fmt.Errorf("couldn't retrieve referenced output PipelineResource %q: %s", r.ResourceRef.Name, err)
 		}
+
 		rtr.Outputs[r.Name] = rr
 	}
 	return &rtr, nil

--- a/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution_test.go
@@ -36,6 +36,11 @@ func TestResolveTaskRun(t *testing.T) {
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "k8s-cluster",
 		},
+	}, {
+		Name: "clusterspecToUse",
+		ResourceSpec: &v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeCluster,
+		},
 	}}
 
 	outputs := []v1alpha1.TaskResourceBinding{{
@@ -47,6 +52,11 @@ func TestResolveTaskRun(t *testing.T) {
 		Name: "gitRepoToUpdate",
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "another-git-repo",
+		},
+	}, {
+		Name: "gitspecToUse",
+		ResourceSpec: &v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeGit,
 		},
 	}}
 
@@ -92,7 +102,7 @@ func TestResolveTaskRun(t *testing.T) {
 		t.Errorf("Task not resolved, expected task's spec to be used but spec was: %v", rtr.TaskSpec)
 	}
 
-	if len(rtr.Inputs) == 2 {
+	if len(rtr.Inputs) == 3 {
 		r, ok := rtr.Inputs["repoToBuildFrom"]
 		if !ok {
 			t.Errorf("Expected value present in map for `repoToBuildFrom' but it was missing")
@@ -109,11 +119,20 @@ func TestResolveTaskRun(t *testing.T) {
 				t.Errorf("Expected to use resource `k8s-cluster` for `clusterToUse` but used %s", r.Name)
 			}
 		}
+		r, ok = rtr.Inputs["clusterspecToUse"]
+		if !ok {
+			t.Errorf("Expected value present in map for `clusterspecToUse' but it was missing")
+		} else {
+			if r.Spec.Type != v1alpha1.PipelineResourceTypeCluster {
+				t.Errorf("Expected to use resource to be of type `cluster` for `clusterspecToUse` but got %s", r.Spec.Type)
+			}
+		}
+
 	} else {
 		t.Errorf("Expected 2 resolved inputs but instead had: %v", rtr.Inputs)
 	}
 
-	if len(rtr.Outputs) == 2 {
+	if len(rtr.Outputs) == 3 {
 		r, ok := rtr.Outputs["imageToBuild"]
 		if !ok {
 			t.Errorf("Expected value present in map for `imageToBuild' but it was missing")
@@ -130,6 +149,14 @@ func TestResolveTaskRun(t *testing.T) {
 				t.Errorf("Expected to use resource `another-git-repo` for `gitRepoToUpdate` but used %s", r.Name)
 			}
 		}
+		r, ok = rtr.Outputs["gitspecToUse"]
+		if !ok {
+			t.Errorf("Expected value present in map for `gitspecToUse' but it was missing")
+		} else {
+			if r.Spec.Type != v1alpha1.PipelineResourceTypeGit {
+				t.Errorf("Expected to use resource type `git` for but got %s", r.Spec.Type)
+			}
+		}
 	} else {
 		t.Errorf("Expected 2 resolved outputs but instead had: %v", rtr.Outputs)
 	}
@@ -143,7 +170,6 @@ func TestResolveTaskRun_missingOutput(t *testing.T) {
 		}}}
 
 	gr := func(n string) (*v1alpha1.PipelineResource, error) { return nil, fmt.Errorf("nope") }
-
 	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", []v1alpha1.TaskResourceBinding{}, outputs, gr)
 	if err == nil {
 		t.Fatalf("Expected to get error because output resource couldn't be resolved")
@@ -156,7 +182,6 @@ func TestResolveTaskRun_missingInput(t *testing.T) {
 		ResourceRef: v1alpha1.PipelineResourceRef{
 			Name: "git-repo",
 		}}}
-
 	gr := func(n string) (*v1alpha1.PipelineResource, error) { return nil, fmt.Errorf("nope") }
 
 	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", inputs, []v1alpha1.TaskResourceBinding{}, gr)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -445,11 +445,11 @@ func (c *Reconciler) createBuildPod(ctx context.Context, tr *v1alpha1.TaskRun, t
 	build = resources.ApplyParameters(build, tr, defaults...)
 
 	// Apply bound resource templating from the taskrun.
-	build, err = resources.ApplyResources(build, tr.Spec.Inputs.Resources, c.resourceLister.PipelineResources(tr.Namespace), "inputs")
+	build, err = resources.ApplyResources(build, tr.Spec.Inputs.Resources, c.resourceLister.PipelineResources(tr.Namespace).Get, "inputs")
 	if err != nil {
 		return nil, fmt.Errorf("couldnt apply input resource templating: %s", err)
 	}
-	build, err = resources.ApplyResources(build, tr.Spec.Outputs.Resources, c.resourceLister.PipelineResources(tr.Namespace), "outputs")
+	build, err = resources.ApplyResources(build, tr.Spec.Outputs.Resources, c.resourceLister.PipelineResources(tr.Namespace).Get, "outputs")
 	if err != nil {
 		return nil, fmt.Errorf("couldnt apply output resource templating: %s", err)
 	}

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -459,10 +459,6 @@ func TaskRunInputsResource(name string, ops ...TaskResourceBindingOp) TaskRunInp
 	return func(i *v1alpha1.TaskRunInputs) {
 		binding := &v1alpha1.TaskResourceBinding{
 			Name: name,
-			ResourceRef: v1alpha1.PipelineResourceRef{
-				// TODO: this seems like an odd default?
-				Name: name,
-			},
 		}
 		for _, op := range ops {
 			op(binding)
@@ -475,6 +471,13 @@ func TaskRunInputsResource(name string, ops ...TaskResourceBindingOp) TaskRunInp
 func TaskResourceBindingRef(name string) TaskResourceBindingOp {
 	return func(b *v1alpha1.TaskResourceBinding) {
 		b.ResourceRef.Name = name
+	}
+}
+
+// TaskResourceBindingResourceSpec set the PipelineResourceResourceSpec to the TaskResourceBinding.
+func TaskResourceBindingResourceSpec(spec *v1alpha1.PipelineResourceSpec) TaskResourceBindingOp {
+	return func(b *v1alpha1.TaskResourceBinding) {
+		b.ResourceSpec = spec
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -130,6 +130,7 @@ func TestTaskRunWitTaskRef(t *testing.T) {
 				),
 				tb.TaskRunInputsResource(anotherGitResource.Name,
 					tb.TaskResourceBindingPaths("source-folder"),
+					tb.TaskResourceBindingResourceSpec(&v1alpha1.PipelineResourceSpec{Type: v1alpha1.PipelineResourceTypeCluster}),
 				),
 				tb.TaskRunInputsParam("iparam", "ivalue"),
 			),
@@ -167,11 +168,9 @@ func TestTaskRunWitTaskRef(t *testing.T) {
 					},
 					Paths: []string{"source-folder"},
 				}, {
-					Name: "another-git-resource",
-					ResourceRef: v1alpha1.PipelineResourceRef{
-						Name: "another-git-resource",
-					},
-					Paths: []string{"source-folder"},
+					Name:         "another-git-resource",
+					ResourceSpec: &v1alpha1.PipelineResourceSpec{Type: v1alpha1.PipelineResourceType("cluster")},
+					Paths:        []string{"source-folder"},
 				}},
 				Params: []v1alpha1.Param{{Name: "iparam", Value: "ivalue"}},
 			},

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -50,7 +50,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 	pipeline := tb.Pipeline("tomatoes", namespace,
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec("tomatoes"))
+	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
 	}


### PR DESCRIPTION
Address #313 issue partially. Another PR about BuildGCS type is yet to be added.

Users moving from build CRD to TaskRun had to declare pipeline resources and taskrun CRDs (2 different resources). To make the migration more seemless from build -> taskrun, this PR will allow embedding resource definition into taskrun spec.

cc @bobcatfish @pivotal-nader-ziada @ImJasonH 