### PR TITLE
Make integration tests run in parallel.

### DIFF
--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -35,6 +35,7 @@ import (
 func TestTaskRunPipelineRunCancel(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -35,6 +35,7 @@ func TestClusterResource(t *testing.T) {
 
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)

--- a/test/gcs_taskrun_test.go
+++ b/test/gcs_taskrun_test.go
@@ -40,6 +40,7 @@ func TestStorageTaskRun(t *testing.T) {
 		t.Skip("KANIKO_SECRET_CONFIG_FILE variable is not set.")
 	}
 	logger := logging.GetContextLogger(t.Name())
+	t.Parallel()
 
 	c, namespace := setup(t, logger)
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -55,6 +55,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
 	setupClusterBindingForHelm(c, t, namespace, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)
@@ -173,7 +174,7 @@ func getHelmDeployTask(namespace string) *v1alpha1.Task {
 		tb.TaskInputs(
 			tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit),
 			tb.InputsParam("pathToHelmCharts", tb.ParamDescription("Path to the helm charts")),
-			tb.InputsParam("image"), tb.InputsParam("chartname"),
+			tb.InputsParam("image"), tb.InputsParam("chartname", tb.ParamDefault("")),
 		),
 		tb.Step("helm-init", "alpine/helm", tb.Args("init", "--wait")),
 		tb.Step("helm-deploy", "alpine/helm", tb.Args(

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -126,6 +126,7 @@ func getTaskRun(namespace string) *v1alpha1.TaskRun {
 func TestKanikoTaskRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	repo, err := getDockerRepo()
 	if err != nil {

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -40,6 +40,7 @@ var (
 )
 
 func TestPipelineRun(t *testing.T) {
+	t.Parallel()
 	type tests struct {
 		name                   string
 		testSetup              func(c *clients, namespace string, index int)

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -30,6 +30,7 @@ import (
 func TestTaskRunPipelineRunStatus(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -29,6 +29,7 @@ import (
 func TestTaskRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)


### PR DESCRIPTION
This cuts the e2e test time from ~10m to ~5m on my test cluster (3 n1-standard4 nodes on GKE 1.11.x).

I ran this ~5 times locally with no failures.