### PR TITLE
Update OWNERS b/c @aaron-prindle is changing teams 🚢

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- aaron-prindle
 - bobcatfish
 - dlorenc
 - ImJasonH


### PR DESCRIPTION
Removing @aaron-prindle as an owner because he has moved on to
another team. Plus we're trying to clean up the OWNERS files so that we
can make more use of the automatic reviewer assignment