### PR TITLE
Remove OWNERS file from test dir

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,9 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- adrcunha
-- dushyanthsc
-- ericKlawitter
-- jessiezcc
-- srinivashegde86
-- steuhs


### PR DESCRIPTION
Having this OWNERS file in the test dir means that when folks submit PRs
that change code in this dir, folks from the productivity WG get tagged
as reviewers. We want to be able to use the automatic reviwer assignment
to help distribute reviews among owners of this repo, so we want to make
sure that only the actual desired reviewers get assigned.

The purpose of adding test/OWNERS was so that the productivity WG could
make urgent changes to the test infrastructure without requiring sign
off from the repo owners. However looking back at the changes that have
gone in:
1. Most required updates to the `vendor` dir as well, which still
   required OWNER sign off
2. Or the changes were minor and could wait for a review (e.g. changing
   comments)

If we decide we still want to keep test/OWNERS, the next option will be
to move the actual tests themselves into another directory (e.g.
`tests`) - we can't move the scripts that are part of the test
infrastructure because they rely on being in a folder called `test`.

(Note the productivity WG are still owners of the `hack` directory - we
can remove this as well but it doesn't cause use the same issues around
review assignment.)

What do you think @adrcunha ?