### PR TITLE
Fix bad format string in resource handling error message

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -85,7 +85,7 @@ func AddInputResource(
 
 		resource, err := getResource(boundResource, pipelineResourceLister.PipelineResources(taskRun.Namespace).Get)
 		if err != nil {
-			return nil, fmt.Errorf("task %q failed to Get Pipeline Resource: %q: error: %s", taskName, boundResource, err.Error())
+			return nil, fmt.Errorf("task %q failed to Get Pipeline Resource: %v: error: %s", taskName, boundResource, err.Error())
 		}
 
 		// if taskrun is fetching resource from previous task then execute copy step instead of fetching new copy

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -93,7 +93,7 @@ func AddOutputResources(
 
 		resource, err := getResource(boundResource, pipelineResourceLister.PipelineResources(taskRun.Namespace).Get)
 		if err != nil {
-			return fmt.Errorf("Failed to get output pipeline Resource for task %q resource %q; error: %s", taskName, boundResource, err.Error())
+			return fmt.Errorf("Failed to get output pipeline Resource for task %q resource %v; error: %s", taskName, boundResource, err.Error())
 		}
 
 		// if resource is declared in input then copy outputs to pvc


### PR DESCRIPTION
Without this change, `go test ./pkg/...` spews lines like:

```
pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go:88:16: Errorf format %q has arg boundResource of wrong type *github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1.TaskResourceBinding
pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go:96:11: Errorf format %q has arg boundResource of wrong type *github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1.TaskResourceBinding
```