### PR TITLE
Task validation : fix variable validation in case of multiple variables 👼

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -151,6 +151,11 @@ TaskRun. Some example use-cases of this include:
 - A Task that supports several different strategies, and leaves the choice up to
   the other.
 
+Parameters name are limited to alpha-numeric characters, `-` and `_`
+and can only start with alpha characters and `_`. For example,
+`fooIs-Bar_` is a valid parameter name, `barIsBa$` or `0banana` are
+not.
+
 ##### Usage
 
 The following example shows how Tasks can be parameterized, and these parameters


### PR DESCRIPTION
There was a problem if a single string contains more than one
variables when validating it. For example, the following Task would
fail validation at creation.

```yaml
apiVersion: pipeline.knative.dev/v1alpha1
kind: Task
metadata:
  name: foo
spec:
  inputs:
    params:
    - name: foo
      description: foo is FOO
      default: banana
    - name: bar
      description: bar is BAR
      default: baz
  steps:
  - name: run-me
    image: busybok
    command: ["/bin/sh", "-c"]
    args: ["echo I am a ${inputs.params.foo} named ${inputs.params.baz}"]
```

The regular expression used was too naive, it is now fixed. Before
this change, the extracted variable would be:

`inputs param.foo} named ${inputs.params.baz`

… and thus, the validation would fail.

With this fix, it extracts both variables and validate both.

/cc @bobcatfish @shashwathi 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>