### PR TITLE
fix broken links in docs/tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -3,9 +3,9 @@
 Welcome to the Pipeline tutorial!
 
 This tutorial will walk you through creating and running some simple
-[`Tasks`](concepts.md#task), [`Pipelines`](concepts.md#pipeline) and running
-them by creating [`TaskRuns`](concepts.md#taskruns) and
-[`PipelineRuns`](concepts.md#pipelineruns).
+[`Tasks`](tasks.md), [`Pipelines`](pipelines.md) and running
+them by creating [`TaskRuns`](taskruns.md) and
+[`PipelineRuns`](pipelineruns.md).
 
 - [Creating a hello world `Task`](#tasks)
 - [Creating a hello world `Pipeline`](#pipelines)
@@ -18,7 +18,7 @@ The main objective of the Pipeline CRDs is to run your Task individually or as a
 part of a Pipeline. Every task runs as a Pod on your Kubernetes cluster with
 each step as its own container.
 
-A [`Task`](concepts.md#task) defines the work that needs to be executed, for
+A [`Task`](tasks.md) defines the work that needs to be executed, for
 example the following is a simple task that will echo hello world:
 
 ```yaml
@@ -38,7 +38,7 @@ spec:
 
 The `steps` are a series of commands to be sequentially executed by the task.
 
-A [`TaskRun`](concepts.md#taskruns) runs the `Task` you defined. Here is a
+A [`TaskRun`](taskruns.md) runs the `Task` you defined. Here is a
 simple example of a `TaskRun` you can use to execute your task:
 
 ```yaml
@@ -330,7 +330,7 @@ resource definition.
 
 # Pipeline
 
-A [`Pipeline`](concepts.md#pipelines) defines a list of tasks to execute in
+A [`Pipeline`](pipelines.md) defines a list of tasks to execute in
 order, while also indicating if any outputs should be used as inputs of a
 following task by using [the `from` field](pipelines.md#from). The same templating
 you used in tasks is also available in pipeline.
@@ -429,7 +429,7 @@ spec:
         - "${inputs.params.path}"
 ```
 
-To run the `Pipeline`, create a [`PipelineRun`](concepts.md#pipelinerun) as
+To run the `Pipeline`, create a [`PipelineRun`](pipelineruns.md) as
 follows:
 
 ```yaml


### PR DESCRIPTION
replaced all links to the `concepts.md#...` doc
with specific target docs instead (`tasks.md`, etc.)