### PR TITLE
Fix pvc vs bucket detection case 🌵

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -302,7 +302,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	rprt := resources.GetNextTask(pr.Name, pipelineState, c.Logger)
 
 	var as artifacts.ArtifactStorageInterface
-	if as, err = artifacts.InitializeArtifactStorage(pr, c.KubeClientSet); err != nil {
+	if as, err = artifacts.InitializeArtifactStorage(pr, c.KubeClientSet, c.Logger); err != nil {
 		c.Logger.Infof("PipelineRun failed to initialize artifact storage %s", pr.Name)
 		return err
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -72,7 +72,7 @@ func AddInputResource(
 	if prNameFromLabel == "" {
 		prNameFromLabel = pvcName
 	}
-	as, err := artifacts.GetArtifactStorage(prNameFromLabel, kubeclient)
+	as, err := artifacts.GetArtifactStorage(prNameFromLabel, kubeclient, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -67,7 +67,7 @@ func AddOutputResources(
 	}
 
 	pvcName := taskRun.GetPipelineRunPVCName()
-	as, err := artifacts.GetArtifactStorage(pvcName, kubeclient)
+	as, err := artifacts.GetArtifactStorage(pvcName, kubeclient, logger)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Depending on the `config-artifact-bucket` configMap, `build-pipeline`
will create either a PVC or GCS Bucket for sharing output between
task(run)s in the pipeline. There was a bug (or missing case) in the
code that checks if it needs to create PVC.

We want to create a PVC in the following cases:
- the `config-artifact-bucket` configMap is missing
- the `config-artifact-bucket` configMap data is empty
- the `config-artifact-bucket` configMap has no
`BucketLocationKey` (aka `location`) *or* it's value is empty.

The 2nd case wasn't correctly handled between
`InitializedArtifactStorage` and `GetArtifactStorage` functions.

/cc @shashwathi 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>