### PR TITLE
Fix README, examples, and re-enable yaml tests 😅

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,16 +10,16 @@ To deploy them to your cluster (after
 kubectl apply -f examples/
 
 # To invoke the build-push Task only
-kubectl apply -f examples/run/task-run.yaml
+kubectl apply -f examples/run/taskrun.yaml
 
 # To invoke the simple Pipeline
-kubectl apply -f examples/run/pipeline-run.yaml
+kubectl apply -f examples/run/pipelinerun.yaml
 
 # To invoke the Pipeline that links outputs
-kubectl apply -f examples/run/output-pipeline-run.yaml
+kubectl apply -f examples/run/output-pipelinerun.yaml
 
 # To invoke the TaskRun with embedded Resource spec and task Spec
-kubectl apply -f examples/run/task-run-resource-spec.yaml
+kubectl apply -f examples/run/resource-spec-taskrun.yaml
 ```
 
 ## Example Pipelines

--- a/examples/pipeline.yaml
+++ b/examples/pipeline.yaml
@@ -18,7 +18,7 @@ spec:
     - name: pathToDockerFile
       value: Dockerfile
     - name: pathToContext
-      value: /workspace/examples/microservices/leeroy-web
+      value: /workspace/workspace/examples/microservices/leeroy-web
     resources:
       inputs:
       - name: workspace
@@ -33,7 +33,7 @@ spec:
     - name: pathToDockerFile
       value: Dockerfile
     - name: pathToContext
-      value: /workspace/examples/microservices/leeroy-app
+      value: /workspace/workspace/examples/microservices/leeroy-app
     resources:
       inputs:
       - name: workspace
@@ -54,7 +54,7 @@ spec:
         - build-skaffold-app
     params:
     - name: path
-      value: /workspace/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+      value: /workspace/workspace/examples/microservices/leeroy-app/kubernetes/deployment.yaml
     - name: yqArg
       value: "-d1"
     - name: yamlPathToImage
@@ -72,7 +72,7 @@ spec:
         - build-skaffold-web
     params:
     - name: path
-      value: /workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+      value: /workspace/workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
     - name: yqArg
       value: "-d1"
     - name: yamlPathToImage

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -33,12 +33,7 @@ install_pipeline_crd
 
 # Run the tests
 failed=0
-# FIXME(vdemeester) add pipelinerun to the test…
-# They are currently block by
-# - https://github.com/knative/build-pipeline/issues/375
-# - https://github.com/knative/build-pipeline/pull/443
-# for test in taskrun pipelinerun; do
-for test in taskrun; do
+for test in taskrun pipelinerun; do
   header "Running YAML e2e tests for ${test}s"
   if ! run_yaml_tests ${test}; then
     echo "ERROR: one or more YAML tests failed"


### PR DESCRIPTION
I tried to run the examples this morning and found that the docs were
wrong and also that the path in the example pipelines was now incorrect.

In https://github.com/knative/build-pipeline/commit/411bc55ac8cbfbf4f8d91544dc5fc42295a5ce4c we disabled the pipelinerun tests due to the PVC issue, but now that #443 is done we should be able to re-enable them hopefully! :tada: 