### PR TITLE
golang format tools

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/taskrun/list"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/templating"
 	"github.com/knative/pkg/apis"

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/apply.go
@@ -15,6 +15,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/build-pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/templating"
 )

--- a/pkg/reconciler/v1alpha1/templating/templating_test.go
+++ b/pkg/reconciler/v1alpha1/templating/templating_test.go
@@ -14,8 +14,9 @@
 package templating_test
 
 import (
-	"github.com/knative/pkg/apis"
 	"testing"
+
+	"github.com/knative/pkg/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/build-pipeline/pkg/reconciler/v1alpha1/templating"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
