### PR TITLE
Fix GCS unit tests which do not test the intended.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -80,6 +80,9 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 				Params: []Param{{
 					Name:  "NotLocation",
 					Value: "doesntmatter",
+				}, {
+					Name:  "type",
+					Value: "gcs",
 				}},
 			},
 		},
@@ -94,6 +97,9 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 				Params: []Param{{
 					Name:  "Location",
 					Value: "",
+				}, {
+					Name:  "type",
+					Value: "gcs",
 				}},
 			},
 		},


### PR DESCRIPTION
Found out that the Location test case for GCSResource has type missing.
The test case does not actually test if the Location parameter is valid
and fails due to PipelineResource has no type specified.
With this change, the test now correctly checks for Location
correctness.