### PR TITLE
Fix README error for running end to end yaml tests.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -200,7 +200,7 @@ go test -v -tags=e2e -count=1 ./test -run ^TestTaskRun$
 To run the YAML e2e tests, run the following command:
 
 ```bash
-./test/e2e-yaml-tests.sh
+./test/e2e-tests-yaml.sh
 ```
 
 ### Adding integration tests


### PR DESCRIPTION
The README points to incorrect `./test/e2e-yaml-tests.sh` file.
Instead it should point to `./test/e2e-tests-yaml.sh`