### PR TITLE
Propagate labels from PipelineRun to TaskRun to Pods

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -360,15 +360,19 @@ func (c *Reconciler) createTaskRun(logger *zap.SugaredLogger, rprt *resources.Re
 		taskRunTimeout = nil
 	}
 
+	labels := make(map[string]string, len(pr.ObjectMeta.Labels)+2)
+	for key, val := range pr.ObjectMeta.Labels {
+		labels[key] = val
+	}
+	labels[pipeline.GroupName+pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
+	labels[pipeline.GroupName+pipeline.PipelineRunLabelKey] = pr.Name
+
 	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rprt.TaskRunName,
 			Namespace:       pr.Namespace,
 			OwnerReferences: pr.GetOwnerReference(),
-			Labels: map[string]string{
-				pipeline.GroupName + pipeline.PipelineLabelKey:    pr.Spec.PipelineRef.Name,
-				pipeline.GroupName + pipeline.PipelineRunLabelKey: pr.Name,
-			},
+			Labels:          labels,
 		},
 		Spec: v1alpha1.TaskRunSpec{
 			TaskRef: &v1alpha1.TaskRef{

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -430,14 +430,6 @@ func (c *Reconciler) createBuildPod(ctx context.Context, tr *v1alpha1.TaskRun, t
 		return nil, fmt.Errorf("translating Build to Pod: %v", err)
 	}
 
-	// Rewrite the pod's OwnerRef to point the TaskRun, instead of a
-	// non-existent build.
-	// TODO(jasonhall): Just set this directly when creating a Pod from a
-	// TaskRun.
-	pod.OwnerReferences = []metav1.OwnerReference{
-		*metav1.NewControllerRef(tr, groupVersionKind),
-	}
-
 	return c.KubeClientSet.CoreV1().Pods(tr.Namespace).Create(pod)
 }
 
@@ -488,10 +480,10 @@ func createRedirectedBuild(ctx context.Context, bs *buildv1alpha1.BuildSpec, tr 
 // makeLabels constructs the labels we will apply to TaskRun resources.
 func makeLabels(s *v1alpha1.TaskRun) map[string]string {
 	labels := make(map[string]string, len(s.ObjectMeta.Labels)+1)
-	labels[pipeline.GroupName+pipeline.TaskRunLabelKey] = s.Name
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}
+	labels[pipeline.GroupName+pipeline.TaskRunLabelKey] = s.Name
 	return labels
 }
 

--- a/test/builder/build.go
+++ b/test/builder/build.go
@@ -46,6 +46,7 @@ func Build(name, namespace string, ops ...BuildOp) *buildv1alpha1.Build {
 	return build
 }
 
+// BuildLabel adds a label to the Build.
 func BuildLabel(key, value string) BuildOp {
 	return func(build *buildv1alpha1.Build) {
 		if build.ObjectMeta.Labels == nil {

--- a/test/builder/owner_reference.go
+++ b/test/builder/owner_reference.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 The Knative Authors
+Copyright 2019 The Knative Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/builder/owner_reference.go
+++ b/test/builder/owner_reference.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// OwnerReferenceOp is an operation which modifies an OwnerReference struct.
+type OwnerReferenceOp func(*metav1.OwnerReference)
+
+// OwnerReferenceAPIVersion sets the APIVersion to the OwnerReference.
+func OwnerReferenceAPIVersion(version string) OwnerReferenceOp {
+    return func(o *metav1.OwnerReference) {
+        o.APIVersion = version
+    }
+}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -243,6 +243,16 @@ func PipelineRunSpec(name string, ops ...PipelineRunSpecOp) PipelineRunOp {
 	}
 }
 
+// PipelineRunLabels adds a label to the PipelineRun.
+func PipelineRunLabel(key, value string) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		if pr.ObjectMeta.Labels == nil {
+			pr.ObjectMeta.Labels = map[string]string{}
+		}
+		pr.ObjectMeta.Labels[key] = value
+	}
+}
+
 // PipelineRunResourceBinding adds bindings from actual instances to a Pipeline's declared resources.
 func PipelineRunResourceBinding(name string, ops ...PipelineResourceBindingOp) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -89,9 +89,15 @@ func TestPipelineRun(t *testing.T) {
 	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
 		Type: duckv1alpha1.ConditionSucceeded,
 	}), tb.PipelineRunStartTime(startTime),
-	))
+	), tb.PipelineRunLabel("label-key", "label-value"))
 	expectedPipelineRun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "pear", Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+		},
 		Spec: v1alpha1.PipelineRunSpec{
 			PipelineRef:    v1alpha1.PipelineRef{Name: "tomatoes"},
 			Trigger:        v1alpha1.PipelineTrigger{Type: v1alpha1.PipelineTriggerTypeManual},

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -68,9 +68,6 @@ type TaskRunOutputsOp func(*v1alpha1.TaskRunOutputs)
 // ResolvedTaskResourcesOp is an operation which modify a ResolvedTaskResources struct.
 type ResolvedTaskResourcesOp func(*resources.ResolvedTaskResources)
 
-// OwnerReferenceOp is an operation which modify an OwnerReference struct.
-type OwnerReferenceOp func(*metav1.OwnerReference)
-
 // StepStateOp is an operation which modify a StepStep struct.
 type StepStateOp func(*v1alpha1.StepState)
 
@@ -353,13 +350,6 @@ func TaskRunOwnerReference(kind, name string, ops ...OwnerReferenceOp) TaskRunOp
 			op(o)
 		}
 		tr.ObjectMeta.OwnerReferences = append(tr.ObjectMeta.OwnerReferences, *o)
-	}
-}
-
-// OwnerReferenceAPIVersion sets the APIVersion to the OwnerReference.
-func OwnerReferenceAPIVersion(version string) OwnerReferenceOp {
-	return func(o *metav1.OwnerReference) {
-		o.APIVersion = version
 	}
 }
 


### PR DESCRIPTION
Previously, labels were propagated from TaskRun to Build, but not from Build to Pod. This PR fixes that, and also propagates labels from PipelineRun to TaskRun, so that users are more easily able to filter, identify, and query Pods created by Build Pipeline.

In all cases, if a user specifies a label whose key overlaps with one of the labels that we set automatically, the user's label is ignored.

As mentioned in `taskrun_test.go`, the current tests do not fully demonstrate that the TaskRun to Pod propagation works correctly since they use Build as an intermediate form for comparison. I am happy to try to address that in this PR by introducing a builder for Pod and using that in the tests, but the changes were already getting a bit heavy in `taskrun_test.go` due to wrapping all of the `BuildSpec`s in a `Build`, so I wanted to submit this first to solicit feedback.

Fixes #458

CC @abayer @jstrachan