### PR TITLE
Use name param to set the cluster resource name

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -172,8 +172,8 @@ cluster. The kubeconfig will be placed in
 
 The Cluster resource has the following parameters:
 
-- Name: The name of the Resource is also given to cluster, will be used in the
-  kubeconfig and also as part of the path to the kubeconfig file
+- Name (required): The name to be given to the target cluster, will be used 
+  in the kubeconfig and also as part of the path to the kubeconfig file
 - URL (required): Host url of the master node
 - Username (required): the user with access to the cluster
 - Password: to be used for clusters with basic auth

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -61,11 +61,12 @@ func NewClusterResource(r *PipelineResource) (*ClusterResource, error) {
 		return nil, fmt.Errorf("ClusterResource: Cannot create a Cluster resource from a %s Pipeline Resource", r.Spec.Type)
 	}
 	clusterResource := ClusterResource{
-		Name: r.Name,
 		Type: r.Spec.Type,
 	}
 	for _, param := range r.Spec.Params {
 		switch {
+		case strings.EqualFold(param.Name, "Name"):
+			clusterResource.Name = param.Value
 		case strings.EqualFold(param.Name, "URL"):
 			clusterResource.URL = param.Value
 		case strings.EqualFold(param.Name, "Revision"):

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -36,6 +36,9 @@ func TestNewClusterResource(t *testing.T) {
 			Spec: PipelineResourceSpec{
 				Type: PipelineResourceTypeCluster,
 				Params: []Param{{
+					Name:  "name",
+					Value: "test_cluster_resource",
+				}, {
 					Name:  "url",
 					Value: "http://10.10.10.10",
 				}, {
@@ -49,7 +52,7 @@ func TestNewClusterResource(t *testing.T) {
 			},
 		},
 		want: &ClusterResource{
-			Name:   "test-cluster-resource",
+			Name:   "test_cluster_resource",
 			Type:   PipelineResourceTypeCluster,
 			URL:    "http://10.10.10.10",
 			CAData: []byte("my-cluster-cert"),
@@ -65,6 +68,9 @@ func TestNewClusterResource(t *testing.T) {
 			Spec: PipelineResourceSpec{
 				Type: PipelineResourceTypeCluster,
 				Params: []Param{{
+					Name:  "name",
+					Value: "test_cluster_resource",
+				}, {
 					Name:  "url",
 					Value: "http://10.10.10.10",
 				}, {
@@ -81,7 +87,7 @@ func TestNewClusterResource(t *testing.T) {
 			},
 		},
 		want: &ClusterResource{
-			Name:     "test-cluster-resource",
+			Name:     "test_cluster_resource",
 			Type:     PipelineResourceTypeCluster,
 			URL:      "http://10.10.10.10",
 			CAData:   []byte("my-cluster-cert"),
@@ -98,6 +104,9 @@ func TestNewClusterResource(t *testing.T) {
 			Spec: PipelineResourceSpec{
 				Type: PipelineResourceTypeCluster,
 				Params: []Param{{
+					Name:  "Name",
+					Value: "test.cluster.resource",
+				}, {
 					Name:  "url",
 					Value: "http://10.10.10.10",
 				}, {
@@ -108,7 +117,7 @@ func TestNewClusterResource(t *testing.T) {
 			},
 		},
 		want: &ClusterResource{
-			Name:     "test-cluster-resource",
+			Name:     "test.cluster.resource",
 			Type:     PipelineResourceTypeCluster,
 			URL:      "http://10.10.10.10",
 			Token:    "my-token",
@@ -124,6 +133,9 @@ func TestNewClusterResource(t *testing.T) {
 			Spec: PipelineResourceSpec{
 				Type: PipelineResourceTypeCluster,
 				Params: []Param{{
+					Name:  "name",
+					Value: "test-cluster-resource",
+				}, {
 					Name:  "url",
 					Value: "http://10.10.10.10",
 				}},

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -36,7 +36,7 @@ func (rs *PipelineResourceSpec) Validate() *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	if rs.Type == PipelineResourceTypeCluster {
-		var usernameFound, cadataFound bool
+		var usernameFound, cadataFound, nameFound bool
 		for _, param := range rs.Params {
 			switch {
 			case strings.EqualFold(param.Name, "URL"):
@@ -47,6 +47,8 @@ func (rs *PipelineResourceSpec) Validate() *apis.FieldError {
 				usernameFound = true
 			case strings.EqualFold(param.Name, "CAData"):
 				cadataFound = true
+			case strings.EqualFold(param.Name, "name"):
+				nameFound = true
 			}
 		}
 
@@ -59,6 +61,9 @@ func (rs *PipelineResourceSpec) Validate() *apis.FieldError {
 			}
 		}
 
+		if !nameFound {
+			return apis.ErrMissingField("name param")
+		}
 		if !usernameFound {
 			return apis.ErrMissingField("username param")
 		}

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -40,6 +40,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 				Spec: PipelineResourceSpec{
 					Type: PipelineResourceTypeCluster,
 					Params: []Param{{
+						Name:  "name",
+						Value: "test-cluster-resource",
+					}, {
 						Name:  "url",
 						Value: "10.10.10",
 					}, {
@@ -67,6 +70,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 				Spec: PipelineResourceSpec{
 					Type: PipelineResourceTypeCluster,
 					Params: []Param{{
+						Name:  "name",
+						Value: "test-cluster-resource",
+					}, {
 						Name:  "url",
 						Value: "http://10.10.10.10",
 					}, {
@@ -82,6 +88,30 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("username param"),
 		},
 		{
+			name: "cluster with missing name",
+			res: PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster-resource",
+					Namespace: "foo",
+				},
+				Spec: PipelineResourceSpec{
+					Type: PipelineResourceTypeCluster,
+					Params: []Param{{
+						Name:  "url",
+						Value: "http://10.10.10.10",
+					}, {
+						Name:  "cadata",
+						Value: "bXktY2x1c3Rlci1jZXJ0Cg",
+					}, {
+						Name:  "token",
+						Value: "my-token",
+					},
+					},
+				},
+			},
+			want: apis.ErrMissingField("name param"),
+		},
+		{
 			name: "cluster with missing cadata",
 			res: PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
@@ -91,6 +121,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 				Spec: PipelineResourceSpec{
 					Type: PipelineResourceTypeCluster,
 					Params: []Param{{
+						Name:  "Name",
+						Value: "test-cluster-resource",
+					}, {
 						Name:  "url",
 						Value: "http://10.10.10.10",
 					}, {
@@ -199,6 +232,9 @@ func TestClusterResourceValidation_Valid(t *testing.T) {
 		Spec: PipelineResourceSpec{
 			Type: PipelineResourceTypeCluster,
 			Params: []Param{{
+				Name:  "name",
+				Value: "test-cluster-resource",
+			}, {
 				Name:  "url",
 				Value: "http://10.10.10.10",
 			}, {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -76,6 +76,9 @@ func setUp() {
 		Spec: v1alpha1.PipelineResourceSpec{
 			Type: "cluster",
 			Params: []v1alpha1.Param{{
+				Name:  "Name",
+				Value: "cluster2",
+			}, {
 				Name:  "Url",
 				Value: "http://10.10.10.10",
 			}},
@@ -93,6 +96,9 @@ func setUp() {
 		Spec: v1alpha1.PipelineResourceSpec{
 			Type: "cluster",
 			Params: []v1alpha1.Param{{
+				Name:  "name",
+				Value: "cluster3",
+			}, {
 				Name:  "Url",
 				Value: "http://10.10.10.10",
 			}, {

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -74,6 +74,7 @@ func TestClusterResource(t *testing.T) {
 func getClusterResource(namespace, name, sname string) *v1alpha1.PipelineResource {
 	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCluster,
+		tb.PipelineResourceSpecParam("Name", "helloworld-cluster"),
 		tb.PipelineResourceSpecParam("Url", "https://1.1.1.1"),
 		tb.PipelineResourceSpecParam("username", "test-user"),
 		tb.PipelineResourceSpecParam("password", "test-password"),


### PR DESCRIPTION
Fixes: #431 

### Proposed changes: 

Get the name of the `ClusterResource` from a `name` param instead of the resource name to allow users to be more flexible with names. Using the resource metadata name forces users to only use DNS-1123 subdomain compliant names