### PR TITLE
golang format tools

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -299,8 +299,8 @@ func MakePod(build *v1alpha1.Build, kubeclient kubernetes.Interface) (*corev1.Po
 			Name: fmt.Sprintf("%s-pod-%s", build.Name, gibberish),
 			// If our parent TaskRun is deleted, then we should be as well.
 			OwnerReferences: build.OwnerReferences,
-			Annotations: annotations,
-			Labels: build.ObjectMeta.Labels,
+			Annotations:     annotations,
+			Labels:          build.ObjectMeta.Labels,
 		},
 		Spec: corev1.PodSpec{
 			// If the build fails, don't restart it.

--- a/test/builder/owner_reference.go
+++ b/test/builder/owner_reference.go
@@ -14,7 +14,7 @@ limitations under the License.
 package builder
 
 import (
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // OwnerReferenceOp is an operation which modifies an OwnerReference struct.
@@ -22,7 +22,7 @@ type OwnerReferenceOp func(*metav1.OwnerReference)
 
 // OwnerReferenceAPIVersion sets the APIVersion to the OwnerReference.
 func OwnerReferenceAPIVersion(version string) OwnerReferenceOp {
-    return func(o *metav1.OwnerReference) {
-        o.APIVersion = version
-    }
+	return func(o *metav1.OwnerReference) {
+		o.APIVersion = version
+	}
 }


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
