### PR TITLE
Format markdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@ High level details of this design:
 - [Tasks](tasks.md) can depend on artifacts, output and parameters created by
   other tasks.
 - [Tasks](tasks.md) can be invoked via [TaskRuns](taskruns.md)
-- [PipelineResources](resources.md) are the artifacts used as inputs and
-  outputs of Tasks.
+- [PipelineResources](resources.md) are the artifacts used as inputs and outputs
+  of Tasks.
 
 ## Usage
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`