### PR TITLE
Check labels in e2e PipelineRun tests and document label propagation

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -97,6 +97,26 @@ of the `TaskRun` resource object.
 For examples and more information about specifying service accounts, see the
 [`ServiceAccount`](./auth.md) reference topic.
 
+## Labels
+
+Any labels specified in the metadata field of a `PipelineRun` will be
+propagated to the `TaskRuns` created automatically for each `Task` in the
+`Pipeline` and then to the `Pods` created for those `TaskRuns`. In addition,
+the following labels will be added automatically:
+
+* `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
+* `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
+
+These labels make it easier to find the resources that are associated with a
+given pipeline.
+
+For example, to find all `Pods` created by a `Pipeline` named test-pipeline,
+you could use the following command:
+
+```shell
+kubectl get pods --all-namespaces -l pipeline.knative.dev/pipeline=test-pipeline
+```
+
 ## Cancelling a PipelineRun
 
 In order to cancel a running pipeline (`PipelineRun`), you need to update its

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -152,6 +152,30 @@ of the `TaskRun` resource object.
 For examples and more information about specifying service accounts, see the
 [`ServiceAccount`](./auth.md) reference topic.
 
+## Labels
+
+Any labels specified in the metadata field of a `TaskRun` will be
+propagated to the `Pod` created to execute the `Task`. In addition,
+the following label will be added automatically:
+
+* `pipeline.knative.dev/taskRun` will contain the name of the `TaskRun`
+
+If the `TaskRun` was created automatically by a `PipelineRun`, then the
+following two labels will also be added to the `TaskRun` and `Pod`:
+
+* `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
+* `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
+
+These labels make it easier to find the resources that are associated with a
+given `TaskRun`.
+
+For example, to find all `Pods` created by a `TaskRun` named test-taskrun,
+you could use the following command:
+
+```shell
+kubectl get pods --all-namespaces -l pipeline.knative.dev/taskRun=test-taskrun
+```
+
 ## Cancelling a TaskRun
 
 In order to cancel a running task (`TaskRun`), you need to update its spec to


### PR DESCRIPTION
The e2e tests in test/pipelinerun.go now assert that custom labels set on the PipelineRun are propagated through to the TaskRun and Pod, and that the static labels that are added to all TaskRuns and Pods are propagated correctly as well.

In addition, documentation has been added to explain that labels are propagated and to mention the specific labels that are added automatically to generated TaskRuns and Pods.

This is a follow-up to #488.

CC @shashwathi @bobcatfish 