### PR TITLE
Format markdown

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -99,19 +99,19 @@ For examples and more information about specifying service accounts, see the
 
 ## Labels
 
-Any labels specified in the metadata field of a `PipelineRun` will be
-propagated to the `TaskRuns` created automatically for each `Task` in the
-`Pipeline` and then to the `Pods` created for those `TaskRuns`. In addition,
-the following labels will be added automatically:
+Any labels specified in the metadata field of a `PipelineRun` will be propagated
+to the `TaskRuns` created automatically for each `Task` in the `Pipeline` and
+then to the `Pods` created for those `TaskRuns`. In addition, the following
+labels will be added automatically:
 
-* `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
-* `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
+- `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
+- `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
 
 These labels make it easier to find the resources that are associated with a
 given pipeline.
 
-For example, to find all `Pods` created by a `Pipeline` named test-pipeline,
-you could use the following command:
+For example, to find all `Pods` created by a `Pipeline` named test-pipeline, you
+could use the following command:
 
 ```shell
 kubectl get pods --all-namespaces -l pipeline.knative.dev/pipeline=test-pipeline

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -172,8 +172,8 @@ cluster. The kubeconfig will be placed in
 
 The Cluster resource has the following parameters:
 
-- Name (required): The name to be given to the target cluster, will be used 
-  in the kubeconfig and also as part of the path to the kubeconfig file
+- Name (required): The name to be given to the target cluster, will be used in
+  the kubeconfig and also as part of the path to the kubeconfig file
 - URL (required): Host url of the master node
 - Username (required): the user with access to the cluster
 - Password: to be used for clusters with basic auth

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -154,23 +154,23 @@ For examples and more information about specifying service accounts, see the
 
 ## Labels
 
-Any labels specified in the metadata field of a `TaskRun` will be
-propagated to the `Pod` created to execute the `Task`. In addition,
-the following label will be added automatically:
+Any labels specified in the metadata field of a `TaskRun` will be propagated to
+the `Pod` created to execute the `Task`. In addition, the following label will
+be added automatically:
 
-* `pipeline.knative.dev/taskRun` will contain the name of the `TaskRun`
+- `pipeline.knative.dev/taskRun` will contain the name of the `TaskRun`
 
 If the `TaskRun` was created automatically by a `PipelineRun`, then the
 following two labels will also be added to the `TaskRun` and `Pod`:
 
-* `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
-* `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
+- `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
+- `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
 
 These labels make it easier to find the resources that are associated with a
 given `TaskRun`.
 
-For example, to find all `Pods` created by a `TaskRun` named test-taskrun,
-you could use the following command:
+For example, to find all `Pods` created by a `TaskRun` named test-taskrun, you
+could use the following command:
 
 ```shell
 kubectl get pods --all-namespaces -l pipeline.knative.dev/taskRun=test-taskrun

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -566,30 +566,55 @@ the status of individual Task runs are shown.
 ### Known good configuration
 
 Knative (as of version 0.3) is known to work with:
-- [Docker for Desktop](https://www.docker.com/products/docker-desktop): a version that uses Kubernetes 1.11 or higher. At the time of this document, this requires the *edge* version of Docker to be installed. A known good configuration specifies six CPUs, 10 GB of memory and 2 GB of swap space
-- The following [prerequisites](https://github.com/knative/build-pipeline/blob/master/DEVELOPMENT.md#requirements)
-- Setting `host.docker.local:5000` as an insecure registry with Docker for Desktop (set via preferences or configuration, see the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/) for details) 
-- Passing `--insecure` as an argument to Kaniko tasks lets us push to an insecure registry
+
+- [Docker for Desktop](https://www.docker.com/products/docker-desktop): a
+  version that uses Kubernetes 1.11 or higher. At the time of this document,
+  this requires the _edge_ version of Docker to be installed. A known good
+  configuration specifies six CPUs, 10 GB of memory and 2 GB of swap space
+- The following
+  [prerequisites](https://github.com/knative/build-pipeline/blob/master/DEVELOPMENT.md#requirements)
+- Setting `host.docker.local:5000` as an insecure registry with Docker for
+  Desktop (set via preferences or configuration, see the
+  [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/)
+  for details)
+- Passing `--insecure` as an argument to Kaniko tasks lets us push to an
+  insecure registry
 - Running a local (insecure) Docker registry: this can be run with
 
 `docker run -d -p 5000:5000 --name registry-srv -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2`
 
-- Optionally, a Docker registry viewer so we can check our pushed images are present:
+- Optionally, a Docker registry viewer so we can check our pushed images are
+  present:
 
 `docker run -it -p 8080:8080 --name registry-web --link registry-srv -e REGISTRY_URL=http://registry-srv:5000/v2 -e REGISTRY_NAME=localhost:5000 hyper/docker-registry-web`
 
 ### Images
-- Any PipelineResource definitions of image type should be updated to use the local registry by setting the url to `host.docker.internal:5000/myregistry/<image name>` equivalents
-- The `KO_DOCKER_REPO` variable should be set to `localhost:5000/myregistry` before using `ko`
-- You are able to push to `host.docker.internal:5000/myregistry/<image name>` but your applications (e.g any deployment definitions) should reference `localhost:5000/myregistry/<image name>`
+
+- Any PipelineResource definitions of image type should be updated to use the
+  local registry by setting the url to
+  `host.docker.internal:5000/myregistry/<image name>` equivalents
+- The `KO_DOCKER_REPO` variable should be set to `localhost:5000/myregistry`
+  before using `ko`
+- You are able to push to `host.docker.internal:5000/myregistry/<image name>`
+  but your applications (e.g any deployment definitions) should reference
+  `localhost:5000/myregistry/<image name>`
 
 ### Logging
-- Logs can remain in-memory only as opposed to sent to a service such as [Stackdriver](https://cloud.google.com/logging/). Achieve this by modifying or deleting entirely (to just use stdout) a PipelineRun or TaskRun's `results` specification.
 
-Elasticsearch can be deployed locally as a means to view logs "after the fact": an example is provided at https://github.com/mgreau/knative-elastic-tutorials.
+- Logs can remain in-memory only as opposed to sent to a service such as
+  [Stackdriver](https://cloud.google.com/logging/). Achieve this by modifying or
+  deleting entirely (to just use stdout) a PipelineRun or TaskRun's `results`
+  specification.
+
+Elasticsearch can be deployed locally as a means to view logs "after the fact":
+an example is provided at https://github.com/mgreau/knative-elastic-tutorials.
 
 ## Experimentation
-Lines of code you may want to configure have the #configure annotation. This annotation applies to subjects such as Docker registries, log output locations and other nuances that may be specific to particular cloud providers or services.
+
+Lines of code you may want to configure have the #configure annotation. This
+annotation applies to subjects such as Docker registries, log output locations
+and other nuances that may be specific to particular cloud providers or
+services.
 
 ---
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`