### PR TITLE
feat: add support for batching multiple commits

### DIFF
--- a/cmd/git-init/utils/env_vars.go
+++ b/cmd/git-init/utils/env_vars.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+)
+
+type PullRefs struct {
+	BaseBranch string
+	BaseSha string
+	ToMerge map[string] string
+}
+
+// ParsePullRefs parses the Prow PULL_REFS env var formatted string and converts to a map of branch:sha
+func ParsePullRefs(pullRefs string) (*PullRefs, error) {
+	kvs := strings.Split(pullRefs, ",")
+	answer := PullRefs{
+		ToMerge: make(map[string]string),
+	}
+	for i, kv := range kvs {
+		s := strings.Split(kv, ":")
+		if len(s) != 2 {
+			return nil, fmt.Errorf("incorrect format for branch:sha %s", kv)
+		}
+		if i == 0 {
+			answer.BaseBranch = s[0]
+			answer.BaseSha = s[1]
+		} else {
+			answer.ToMerge[s[0]] = s[1]
+		}
+	}
+	return &answer, nil
+}

--- a/cmd/git-init/utils/env_vars_test.go
+++ b/cmd/git-init/utils/env_vars_test.go
@@ -1,0 +1,25 @@
+package utils_test
+
+import (
+	"github.com/knative/build-pipeline/cmd/git-init/utils"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePullRefs(t *testing.T) {
+	pullRefs := "master:ef08a6cd194c2687d4bc12df6bb8a86f53c348ba,2739:5b351f4eae3c4afbb90dd7787f8bf2f8c454723f,2822:bac2a1f34fd54811fb767f69543f59eb3949b2a5"
+	shas, err := utils.ParsePullRefs(pullRefs)
+	assert.NoError(t, err)
+
+	expected := &utils.PullRefs{
+		BaseBranch: "master",
+		BaseSha: "ef08a6cd194c2687d4bc12df6bb8a86f53c348ba",
+		ToMerge: map[string]string{
+			"2739": "5b351f4eae3c4afbb90dd7787f8bf2f8c454723f",
+			"2822": "bac2a1f34fd54811fb767f69543f59eb3949b2a5",
+		},
+	}
+
+	assert.Equal(t, expected, shas)
+}

--- a/cmd/git-init/utils/fetch_and_merge.go
+++ b/cmd/git-init/utils/fetch_and_merge.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"fmt"
+	"go.uber.org/zap"
+)
+
+// FetchAndMergeSHAs merges any SHAs into the refs.BaseBranch which has a tip of refs.BaseSha,
+// fetching the commits from remote for the git repo in dir. It will try to fetch individual commits (
+// if the remote repo supports it - see https://github.
+// com/git/git/commit/68ee628932c2196742b77d2961c5e16360734a62) otherwise it uses git remote update to pull down the
+// whole repo.
+func FetchAndMergeSHAs(refs *PullRefs, remote string, dir string, logger *zap.SugaredLogger)  {
+	refspecs := make([]string, 0)
+	for _, sha := range refs.ToMerge {
+		refspecs = append(refspecs, fmt.Sprintf("%s:", sha))
+	}
+	refspecs = append(refspecs, refs.BaseSha)
+	// First lets make sure we have the commits - remember that this is a shallow clone
+	args := []string{"fetch", remote}
+	for _, refspec := range refspecs {
+		args = append(args, refspec)
+	}
+	_, err := Run("git", dir, args... )
+	if err != nil {
+		// This can be caused by git not being configured to allow fetching individual SHAs
+		// There is not a nice way to solve this except to attempt to do a full fetch
+		out, err := Run ("git", dir, "remote", "update")
+		if err != nil {
+			logger.Fatalf( "updating remote %s, output was %s, err was %v", remote, out, err)
+		}
+	}
+	// Ensure we are on refs.BaseBranch
+	out, err := Run("git", dir, "checkout", refs.BaseBranch)
+	if err != nil {
+		logger.Fatalf( "checking out %s, output was %s, err was %v", refs.BaseBranch, out, err)
+	}
+	// Ensure we are on the right revision
+	out, err = Run ("git", dir, "reset", "--hard", refs.BaseSha)
+	if err != nil {
+		logger.Fatalf( "resetting %s to %s, output was %s, err was %v", refs.BaseBranch, refs.BaseSha, out, err)
+	}
+	out, err = Run("git", dir, "clean", "--force", "-d")
+	if err != nil {
+		logger.Fatalf("cleaning up the git repo, output was %s, err was %v", out)
+	}
+	// Now do the merges
+	for _, sha := range refs.ToMerge {
+		out, err := Run("git", dir,"merge", sha)
+		if err != nil {
+
+			logger.Fatalf( "merging %s into master, output was %s, err was %v", sha, out, err)
+		}
+	}
+}
+
+

--- a/cmd/git-init/utils/fetch_and_merge_test.go
+++ b/cmd/git-init/utils/fetch_and_merge_test.go
@@ -1,0 +1,202 @@
+package utils_test
+
+import (
+	"github.com/knative/build-pipeline/cmd/git-init/utils"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/knative/pkg/logging"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	initialReadme       = "Cheesy!"
+	commit1Readme       = "Yet more cheese!"
+	commit2Contributing = "Even more cheese!"
+	commit3License      = "It's cheesy!"
+	contributing        = "CONTRIBUTING"
+	readme              = "README"
+	license             = "LICENSE"
+)
+
+func TestFetchAndMergeOneSHA(t *testing.T) {
+	logger, _ := logging.NewLogger("", "git-init")
+	// This test only uses local repos, so it's safe to use real git
+	env := prepareFetchAndMergeTests(t)
+	defer env.Cleanup()
+	// Test merging one commit
+	refs := &utils.PullRefs{
+		ToMerge: map[string]string{
+			"1": env.Sha1,
+	},
+		BaseSha: env.BaseSha,
+		BaseBranch: "master",
+	}
+	utils.FetchAndMergeSHAs(refs, "origin", env.LocalDir, logger)
+	readmeFile, err := ioutil.ReadFile(env.ReadmePath)
+	assert.NoError(t, err)
+	assert.Equal(t, commit1Readme, string(readmeFile))
+}
+
+func TestFetchAndMergeMultipleSHAs(t *testing.T) {
+	logger, _ := logging.NewLogger("", "git-init")
+
+	// This test only uses local repos, so it's safe to use real git
+	env := prepareFetchAndMergeTests(t)
+	defer env.Cleanup()
+
+	// Test merging two commit
+	refs := &utils.PullRefs{
+		ToMerge: map[string]string{
+			"1": env.Sha1,
+			"2": env.Sha2,
+		},
+		BaseSha: env.BaseSha,
+		BaseBranch: "master",
+	}
+	utils.FetchAndMergeSHAs(refs, "origin", env.LocalDir, logger)
+	localContributingPath := filepath.Join(env.LocalDir, contributing)
+	readmeFile, err := ioutil.ReadFile(env.ReadmePath)
+	assert.NoError(t, err)
+	assert.Equal(t, commit1Readme, string(readmeFile))
+	contributingFile, err := ioutil.ReadFile(localContributingPath)
+	assert.NoError(t, err)
+	assert.Equal(t, commit2Contributing, string(contributingFile))
+}
+
+func TestFetchAndMergeSHAAgainstNonHEADSHA(t *testing.T) {
+
+	logger, _ := logging.NewLogger("", "git-init")
+
+
+	// This test only uses local repos, so it's safe to use real git
+	env := prepareFetchAndMergeTests(t)
+	defer env.Cleanup()
+
+	refs := &utils.PullRefs{
+		ToMerge: map[string]string{
+			"3": env.Sha3,
+		},
+		BaseSha: env.Sha1,
+		BaseBranch: "master",
+	}
+	// Test merging two commit
+	utils.FetchAndMergeSHAs(refs, "origin", env.LocalDir, logger)
+
+	readmeFile, err := ioutil.ReadFile(env.ReadmePath)
+	assert.NoError(t, err)
+	assert.Equal(t, commit1Readme, string(readmeFile))
+
+	localContributingPath := filepath.Join(env.LocalDir, contributing)
+	_, err = os.Stat(localContributingPath)
+	assert.True(t, os.IsNotExist(err))
+
+	localLicensePath := filepath.Join(env.LocalDir, license)
+	licenseFile, err := ioutil.ReadFile(localLicensePath)
+	assert.NoError(t, err)
+	assert.Equal(t, commit3License, string(licenseFile))
+}
+
+type FetchAndMergeTestEnv struct {
+	BaseSha    string
+	LocalDir   string
+	Sha1       string
+	Sha2       string
+	Sha3       string
+	ReadmePath string
+	Cleanup    func()
+}
+
+func prepareFetchAndMergeTests(t *testing.T) FetchAndMergeTestEnv {
+
+	// Prepare a git repo to test - this is our "remote"
+	remoteDir, err := ioutil.TempDir("", "remote")
+	assert.NoError(t, err)
+	_, err = utils.Run("git",remoteDir, "init")
+	assert.NoError(t, err)
+
+	readmePath := filepath.Join(remoteDir, readme)
+	contributingPath := filepath.Join(remoteDir, contributing)
+	licensePath := filepath.Join(remoteDir, license)
+	err = ioutil.WriteFile(readmePath, []byte(initialReadme), 0600)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir,"add", readme)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "commit", "-m", "Initial Commit")
+	assert.NoError(t, err)
+
+	// Prepare another git repo, this is local repo
+	localDir, err := ioutil.TempDir("", "local")
+	assert.NoError(t, err)
+	_, err = utils.Run("git", localDir,"init")
+	assert.NoError(t, err)
+	// Set up the remote
+	out, err := utils.Run("git", localDir, "remote", "add", "origin", remoteDir)
+	t.Log(out)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", localDir, "fetch", "origin", "master")
+	assert.NoError(t, err)
+	_, err = utils.Run("git", localDir, "merge", "origin/master")
+	assert.NoError(t, err)
+
+	localReadmePath := filepath.Join(localDir, readme)
+	readmeFile, err := ioutil.ReadFile(localReadmePath)
+	assert.NoError(t, err)
+	assert.Equal(t, initialReadme, string(readmeFile))
+	baseSha, err := utils.Run("git", localDir, "rev-parse", "HEAD")
+	assert.NoError(t, err)
+
+	// Add some commits to master on the remote
+	err = ioutil.WriteFile(readmePath, []byte(commit1Readme), 0600)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "add", readme)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "commit", "-m","More Cheese")
+	assert.NoError(t, err)
+	sha1, err := utils.Run("git", remoteDir, "rev-parse", "HEAD")
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(contributingPath, []byte(commit2Contributing), 0600)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "add", contributing)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "commit", "-m","Even More Cheese")
+	assert.NoError(t, err)
+	sha2, err := utils.Run("git", remoteDir, "rev-parse", "HEAD")
+	assert.NoError(t, err)
+
+	// Put some commits on a branch
+	branchName := "another"
+
+	_, err = utils.Run("git", remoteDir, "branch", branchName, baseSha)
+		assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "checkout", branchName)
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(licensePath, []byte(commit3License), 0600)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "add", license)
+	assert.NoError(t, err)
+	_, err = utils.Run("git", remoteDir, "commit", "-m", "Even More Cheese")
+	assert.NoError(t, err)
+	sha3, err := utils.Run("git", remoteDir, "rev-parse", "HEAD")
+	assert.NoError(t, err)
+
+	return FetchAndMergeTestEnv{
+		BaseSha:    baseSha,
+		LocalDir:   localDir,
+		Sha1:       sha1,
+		Sha2:       sha2,
+		Sha3:       sha3,
+		ReadmePath: localReadmePath,
+		Cleanup: func() {
+			err := os.RemoveAll(localDir)
+			assert.NoError(t, err)
+			err = os.RemoveAll(remoteDir)
+			assert.NoError(t, err)
+		},
+	}
+}

--- a/cmd/git-init/utils/run.go
+++ b/cmd/git-init/utils/run.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"go.uber.org/zap"
+	"os/exec"
+	"strings"
+)
+
+func RunAndError(logger *zap.SugaredLogger, cmd string, args ...string) {
+	if output, err := Run(cmd, "", args...); err != nil {
+		logger.Errorf("Error running %v %v: %v\n%v", cmd, args, err, output)
+	}
+}
+
+func Run(cmd string, dir string, args ...string) (string, error) {
+	c := exec.Command(cmd, args...)
+	if dir != "" {
+		c.Dir = dir
+	}
+	out, err :=  c.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func RunOrFail(logger *zap.SugaredLogger, cmd string, args ...string) {
+	if output, err := Run(cmd, "", args...); err != nil {
+		logger.Fatalf("Unexpected error running %v %v: %v\n%v", cmd, args, err, output)
+	}
+}


### PR DESCRIPTION
This is a feature supported by Prow. Multiple 
branch:commits pairs can be specified in the env 
var `PULL_REFS`. The first pair is the 
branch:commit base, any subsequent pairs are 
commits to merge into the first pair.

This PR parses the `PULL_REFS` env var, and then
uses the git CLI to fetch any refs and then merge
them in.

Test coverage is about 80% - the success paths are
covered, error paths are not.