### PR TITLE
Add release notes and submitter checklist to pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
+
+## Changes
+
+<!-- Describe your changes here- ideally you can get that description straight from
+your descriptive commit message(s)! -->
+
+## Submitter Checklist
+
+These are the criteria that every PR should meet, please check them off as you
+review them:
+
+- [ ] Includes [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
+- [ ] Includes [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
+- [ ] Commit messages follow [commit message best practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)
+
+_See [the contribution guide](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md) for more details._
+
+## Release Notes
+
+<!--
+Does your PR contain User facing changes?
+
+If so, breifly describe them here so we can include this description in the
+release notes for the next release!
+-->
+
+```release-note
+
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,9 @@ Unit test coverage should increase or stay the same with every PR.
 
 This means that most PRs should include both:
 
-- Tests
-- Documentation explaining features being added, including updates to
+- [Tests](https://github.com/knative/build-pipeline/tree/master/test#tests)
+- [Documentation](https://github.com/knative/build-pipeline/tree/master/docs)
+  explaining features being added, including updates to
   [DEVELOPMENT.md](./DEVELOPMENT.md) if required
 
 ## Development Process

--- a/hack/release.md
+++ b/hack/release.md
@@ -97,3 +97,12 @@ The release will be published in the _Releases_ page of the Knative Build
 Pipeline repository, with the title _Knative Build Pipeline release vX.Y.Z_ and
 the given release notes. It will also be tagged _vX.Y.Z_ (both on GitHub and as
 a git annotated tag).
+
+#### Release notes
+
+Release notes will need to be manually collected for the release by looking at the
+`Release Notes` section of every PR which has been merged between the last release
+and the current one.
+
+Visiting [github.com/knative/build-pipeline/compare](https://github.com/knative/build-pipeline/compare)
+will allow you to compare changes between git tags.


### PR DESCRIPTION
Add a release notes section to each PR which can be scraped to create
each release. We may eventually want to create a
[changelog file](https://keepachangelog.com/en/0.3.0/) in the repo as
well but for now we can use the PRs and releases.

Since I was adding a pull request template anyway, I got started on a
submitter checklist as well, which we can iterate on and add more
specific items to as they come up.

For versioning, we're going to start with 0.1 and establish a regular
release schedule which we will probably iterate on. We will be following
semantic versioning (https://semver.org/).

Fixes #72