### PR TITLE
Make docs accurate for 0.1 release

### DIFF
--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -7,8 +7,9 @@ specific contract.
 
 When containers are run in a `Task`, the `entrypoint` of the container will be
 overwritten with a custom binary that redirects the logs to a separate location
-for aggregating the log output. As such, it is always recommended to explicitly
-specify a command.
+for aggregating the log output (this currently does nothing but is to support
+future work, see [#107](https://github.com/knative/build-pipeline/issues/107)).
+As such, it is always recommended to explicitly specify a command.
 
 When `command` is not explicitly set, the controller will attempt to lookup the
 entrypoint from the remote registry.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -174,7 +174,6 @@ Express this dependency by adding `from` on `Resources` that your `Tasks` need.
   `PipelineTasks` (i.e. the named instance of a `Task`) in the `Pipeline`
 - When the `from` key is specified on an input source, the version of the
   resource that is from the defined list of tasks is used
-- `from` can support fan in and fan out
 - The name of the `PipelineResource` must correspond to a `PipelineResource`
   from the `Task` that the referenced `PipelineTask` gives as an output
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -141,7 +141,9 @@ Params that can be added are the following:
 2. `digest`: The
    [image digest](https://success.docker.com/article/images-tagging-vs-digests)
    which uniquely identifies a particular build of an image with a particular
-   tag.
+   tag. _While this can be provided as a parameter, there is not yet a way to
+   update this value after an image is built, but this is planned in
+   [#216](https://github.com/knative/build-pipeline/issues/216)._
 
 For example:
 
@@ -172,20 +174,20 @@ cluster. The kubeconfig will be placed in
 
 The Cluster resource has the following parameters:
 
-- Name (required): The name to be given to the target cluster, will be used in
+- `name` (required): The name to be given to the target cluster, will be used in
   the kubeconfig and also as part of the path to the kubeconfig file
-- URL (required): Host url of the master node
-- Username (required): the user with access to the cluster
-- Password: to be used for clusters with basic auth
-- Token: to be used for authentication, if present will be used ahead of the
+- `url` (required): Host url of the master node
+- `username` (required): the user with access to the cluster
+- `password`: to be used for clusters with basic auth
+- `token`: to be used for authentication, if present will be used ahead of the
   password
-- Insecure: to indicate server should be accessed without verifying the TLS
+- `insecure`: to indicate server should be accessed without verifying the TLS
   certificate.
-- CAData (required): holds PEM-encoded bytes (typically read from a root
+- `cadata` (required): holds PEM-encoded bytes (typically read from a root
   certificates bundle).
 
 Note: Since only one authentication technique is allowed per user, either a
-token or a password should be provided, if both are provided, the password will
+`token` or a `password` should be provided, if both are provided, the `password` will
 be ignored.
 
 The following example shows the syntax and structure of a Cluster Resource:
@@ -278,9 +280,12 @@ spec:
 Storage resource represents blob storage, that contains either an object or
 directory. Adding the storage resource as an input to a Task will download the
 blob and allow the Task to perform the required actions on the contents of the
-blob. Blob storage type
+blob.
+
+Only blob storage type
 [Google Cloud Storage](https://cloud.google.com/storage/)(gcs) is supported as
-of now.
+of now via [GCS storage resource](#gcs-storage-resource) and
+[BuildGCS storage resource](#buildgcs-storage-resource).
 
 #### GCS Storage Resource
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -17,6 +17,7 @@ A `TaskRun` runs until all `steps` have completed or until a failure occurs.
   - [Providing resources](#providing-resources)
   - [Overriding where resources are copied from](#overriding-where-resources-are-copied-from)
   - [Service Account](#service-account)
+- [Labels](#labels)
 - [Cancelling a TaskRun](#cancelling-a-taskrun)
 - [Examples](#examples)
 
@@ -152,44 +153,6 @@ of the `TaskRun` resource object.
 For examples and more information about specifying service accounts, see the
 [`ServiceAccount`](./auth.md) reference topic.
 
-## Labels
-
-Any labels specified in the metadata field of a `TaskRun` will be propagated to
-the `Pod` created to execute the `Task`. In addition, the following label will
-be added automatically:
-
-- `pipeline.knative.dev/taskRun` will contain the name of the `TaskRun`
-
-If the `TaskRun` was created automatically by a `PipelineRun`, then the
-following two labels will also be added to the `TaskRun` and `Pod`:
-
-- `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
-- `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
-
-These labels make it easier to find the resources that are associated with a
-given `TaskRun`.
-
-For example, to find all `Pods` created by a `TaskRun` named test-taskrun, you
-could use the following command:
-
-```shell
-kubectl get pods --all-namespaces -l pipeline.knative.dev/taskRun=test-taskrun
-```
-
-## Cancelling a TaskRun
-
-In order to cancel a running task (`TaskRun`), you need to update its spec to
-mark it as cancelled. Running Pods will be deleted.
-
-```yaml
-apiVersion: pipeline.knative.dev/v1alpha1
-kind: TaskRun
-metadata:
-  name: go-example-git
-spec:
-  # […]
-  status: "TaskRunCancelled"
-```
 
 ### Overriding where resources are copied from
 
@@ -223,7 +186,6 @@ metadata:
   name: volume-task
   namespace: default
 spec:
-  generation: 1
   inputs:
     resources:
       - name: workspace
@@ -262,6 +224,45 @@ spec:
   volumes:
     - name: custom-volume
       emptyDir: {}
+```
+
+## Labels
+
+Any labels specified in the metadata field of a `TaskRun` will be propagated to
+the `Pod` created to execute the `Task`. In addition, the following label will
+be added automatically:
+
+- `pipeline.knative.dev/taskRun` will contain the name of the `TaskRun`
+
+If the `TaskRun` was created automatically by a `PipelineRun`, then the
+following two labels will also be added to the `TaskRun` and `Pod`:
+
+- `pipeline.knative.dev/pipeline` will contain the name of the `Pipeline`
+- `pipeline.knative.dev/pipelineRun` will contain the name of the `PipelineRun`
+
+These labels make it easier to find the resources that are associated with a
+given `TaskRun`.
+
+For example, to find all `Pods` created by a `TaskRun` named test-taskrun, you
+could use the following command:
+
+```shell
+kubectl get pods --all-namespaces -l pipeline.knative.dev/taskRun=test-taskrun
+```
+
+## Cancelling a TaskRun
+
+In order to cancel a running task (`TaskRun`), you need to update its spec to
+mark it as cancelled. Running Pods will be deleted.
+
+```yaml
+apiVersion: pipeline.knative.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "TaskRunCancelled"
 ```
 
 ## Examples

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -87,10 +87,6 @@ metadata:
   name: example-task-name
 spec:
   serviceAccountName: task-auth-example
-  source:
-    git:
-      url: https://github.com/example/build-example.git
-      revision: master
   inputs:
     resources:
     - name: workspace
@@ -107,10 +103,8 @@ spec:
   - name: ubuntu-example
     image: ubuntu
     args: ["ubuntu-build-example", "SECRETS-example.md"]
-  steps:
   - image: gcr.io/example-builders/build-example
     args: ['echo', '${inputs.resources.params.pathToDockerFile}']
-  steps:
   - name: dockerfile-pushexample
     image: gcr.io/example-builders/push-example
     args: ["push", "${outputs.resources.builtImage.url}"]
@@ -151,8 +145,6 @@ TaskRun. Some example use-cases of this include:
 - A Task that needs to know what compilation flags to use when building an
   application.
 - A Task that needs to know what to name a built artifact.
-- A Task that supports several different strategies, and leaves the choice up to
-  the other.
 
 Parameters name are limited to alpha-numeric characters, `-` and `_` and can
 only start with alpha characters and `_`. For example, `fooIs-Bar_` is a valid
@@ -341,7 +333,7 @@ Or for an output resource:
 ${outputs.resources.<name>.<key>}
 ```
 
-To access an input parameter, replace `resources` with `params`. 
+To access an input parameter, replace `resources` with `params`.
 
 ```shell
 ${inputs.params.<name>}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -293,9 +293,6 @@ spec:
         paths: null
         resourceRef:
           name: skaffold-image-leeroy-web
-  results:
-    type: gcs
-    url: gcs://somebucket/results/logs #configure: remove results entirely if you're happy to use stdout
   taskRef:
     name: build-docker-image-from-git-source
   taskSpec: null
@@ -331,7 +328,7 @@ resource definition.
 
 # Pipeline
 
-A [`Pipeline`](pipelines.md) defines a list of tasks to execute in order, while
+A [`Pipeline`](pipelines.md) defines a list of tasks to execute, while
 also indicating if any outputs should be used as inputs of a following task by
 using [the `from` field](pipelines.md#from). The same templating you used in
 tasks is also available in pipeline.
@@ -602,9 +599,7 @@ Knative (as of version 0.3) is known to work with:
 ### Logging
 
 - Logs can remain in-memory only as opposed to sent to a service such as
-  [Stackdriver](https://cloud.google.com/logging/). Achieve this by modifying or
-  deleting entirely (to just use stdout) a PipelineRun or TaskRun's `results`
-  specification.
+  [Stackdriver](https://cloud.google.com/logging/).
 
 Elasticsearch can be deployed locally as a means to view logs "after the fact":
 an example is provided at https://github.com/mgreau/knative-elastic-tutorials.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ kubectl apply -f examples/taskruns/resource-spec-taskrun.yaml
 ```
 
 ## Results
+
 You can track the progress of your taskruns and pipelineruns with this command, which will also
 format the output nicely.
 

--- a/examples/pipelineruns/pipelinerun.yaml
+++ b/examples/pipelineruns/pipelinerun.yaml
@@ -1,9 +1,9 @@
----        
+---
 apiVersion: pipeline.knative.dev/v1alpha1
 kind: PipelineResource
 metadata:
   name: skaffold-image-leeroy-app
-spec:        
+spec:
   type: image
   params:
   - name: url
@@ -30,7 +30,7 @@ apiVersion: pipeline.knative.dev/v1alpha1
 kind: PipelineResource
 metadata:
   name: skaffold-image-leeroy-web
-spec:        
+spec:
   type: image
   params:
   - name: url
@@ -217,9 +217,6 @@ spec:
   trigger:
     type: manual
   serviceAccount: 'default'
-  results:
-    type: 'gcs'
-    url: 'gcs://somebucket/results/logs'
   resources:
   - name: source-repo
     resourceRef:

--- a/examples/taskruns/taskrun.yaml
+++ b/examples/taskruns/taskrun.yaml
@@ -2,7 +2,7 @@ apiVersion: pipeline.knative.dev/v1alpha1
 kind: PipelineResource
 metadata:
   name: skaffold-image-leeroy-web
-spec:        
+spec:
   type: image
   params:
   - name: url
@@ -76,9 +76,6 @@ spec:
     name: build-push-kaniko
   trigger:
     type: manual
-  results:
-    type: 'gcs'
-    url: 'gcs://somebucket/results/logs'
   inputs:
     resources:
     - name: workspace


### PR DESCRIPTION
A lot of our docs were created aspirationally, to describe functionality
before it existed. Most of this has since been implemented, but some is
still to implement (graph based execution, updating image digests on
image outputs, results config), so this commit updates the docs to make
sure that someone using a 0.1 release can look at the docs (as of that
git tag) and what they see will be accurate.

Docs were in pretty good shape, just had to make a few changes:

- Make it clear digests arent updated for images
- Remove results config from examples and tutorials
- Removed "fan in and fan out" item from description of `from`
  functoinality - this is kinda technically true, but only in the sense
  of the resources being shared, not in the sense fo the order of
  execution supporting fan in and fan out (yet!)
- For some reason the first example in tasks.md was a bit mangled
  (probably some bad copy pasta on my part!) so fixed that

A few other cosmetic changes (e.g. adding formatting for fields, adding
missing sections to TOCs).

Fixes #386