### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
@@ -47,7 +47,7 @@ func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.Reso
 			continue
 		}
 		rprt.TaskRun.Spec.Status = v1alpha1.TaskRunSpecStatusCancelled
-		if _, err := clientSet.PipelineV1alpha1().TaskRuns(pr.Namespace).UpdateStatus(rprt.TaskRun); err != nil {
+		if _, err := clientSet.PipelineV1alpha1().TaskRuns(pr.Namespace).Update(rprt.TaskRun); err != nil {
 			errs = append(errs, err.Error())
 			continue
 		}

--- a/test/wait.go
+++ b/test/wait.go
@@ -58,7 +58,7 @@ import (
 
 const (
 	interval = 1 * time.Second
-	timeout  = 5 * time.Minute
+	timeout  = 10 * time.Minute
 )
 
 // TaskRunStateFn is a condition function on TaskRun used polling functions


### PR DESCRIPTION
- Refactor go e2e test `TestTaskRunPipelineRunCancel` to reduce flakiness.
- Refactor yaml e2e test bash script. yaml script checks for both
taskruns, pipelineruns to be in unknown status and then check results.

Fixes https://github.com/knative/build-pipeline/issues/511

 i will trigger e2e test couple of times to check whether this change fixes it or not.

cc @bobcatfish