### PR TITLE
Format markdown

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -189,8 +189,8 @@ The Cluster resource has the following parameters:
   certificates bundle).
 
 Note: Since only one authentication technique is allowed per user, either a
-`token` or a `password` should be provided, if both are provided, the `password` will
-be ignored.
+`token` or a `password` should be provided, if both are provided, the `password`
+will be ignored.
 
 The following example shows the syntax and structure of a Cluster Resource:
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -153,7 +153,6 @@ of the `TaskRun` resource object.
 For examples and more information about specifying service accounts, see the
 [`ServiceAccount`](./auth.md) reference topic.
 
-
 ### Overriding where resources are copied from
 
 When specifying input and output `PipelineResources`, you can optionally specify

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -89,31 +89,31 @@ spec:
   serviceAccountName: task-auth-example
   inputs:
     resources:
-    - name: workspace
-      type: git
+      - name: workspace
+        type: git
     params:
-    - name: pathToDockerFile
-      description: The path to the dockerfile to build
-      default: /workspace/workspace/Dockerfile
+      - name: pathToDockerFile
+        description: The path to the dockerfile to build
+        default: /workspace/workspace/Dockerfile
   outputs:
     resources:
-    - name: builtImage
-      type: image
+      - name: builtImage
+        type: image
   steps:
-  - name: ubuntu-example
-    image: ubuntu
-    args: ["ubuntu-build-example", "SECRETS-example.md"]
-  - image: gcr.io/example-builders/build-example
-    args: ['echo', '${inputs.resources.params.pathToDockerFile}']
-  - name: dockerfile-pushexample
-    image: gcr.io/example-builders/push-example
-    args: ["push", "${outputs.resources.builtImage.url}"]
-    volumeMounts:
-    - name: docker-socket-example
-      mountPath: /var/run/docker.sock
+    - name: ubuntu-example
+      image: ubuntu
+      args: ["ubuntu-build-example", "SECRETS-example.md"]
+    - image: gcr.io/example-builders/build-example
+      args: ["echo", "${inputs.resources.params.pathToDockerFile}"]
+    - name: dockerfile-pushexample
+      image: gcr.io/example-builders/push-example
+      args: ["push", "${outputs.resources.builtImage.url}"]
+      volumeMounts:
+        - name: docker-socket-example
+          mountPath: /var/run/docker.sock
   volumes:
-  - name: example-volume
-    emptyDir: {}
+    - name: example-volume
+      emptyDir: {}
 ```
 
 ### Steps
@@ -308,7 +308,9 @@ For example, use volumes to accomplish one of the following common tasks:
 - [Mount a Kubernetes secret](./auth.md).
 - Create an `emptyDir` volume to act as a cache for use across multiple build
   steps. Consider using a persistent volume for inter-build caching.
-- Mount [Kubernetes configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) as volume source.
+- Mount
+  [Kubernetes configmap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+  as volume source.
 - Mount a host's Docker socket to use a `Dockerfile` for container image builds.
   **Note:** Building a container image using `docker build` on-cluster is _very
   unsafe_. Use [kaniko](https://github.com/GoogleContainerTools/kaniko) instead.
@@ -338,7 +340,10 @@ To access an input parameter, replace `resources` with `params`.
 ```shell
 ${inputs.params.<name>}
 ```
-**Note**: Task volume names and volume source(current support includes only configmap) can also be parameterized as shown in [example](#using-kubernetes-configmap-as-volume-source)
+
+**Note**: Task volume names and volume source(current support includes only
+configmap) can also be parameterized as shown in
+[example](#using-kubernetes-configmap-as-volume-source)
 
 ## Examples
 
@@ -437,16 +442,16 @@ spec:
       emptyDir: {}
 ```
 
-####  Using Kubernetes Configmap as Volume Source
+#### Using Kubernetes Configmap as Volume Source
 
 ```yaml
 spec:
   inputs:
     params:
-    - name: CFGNAME
-      description: Name of config map
-    - name: volumeName
-      description: Name of volume
+      - name: CFGNAME
+        description: Name of config map
+      - name: volumeName
+        description: Name of volume
   steps:
     - image: ubuntu
       entrypoint: ["bash"]
@@ -456,9 +461,9 @@ spec:
           mountPath: /var/configmap
 
   volumes:
-  - name: "${inputs.params.volumeName}"
-    configMap:
-      name: "${inputs.params.CFGNAME}"
+    - name: "${inputs.params.volumeName}"
+      configMap:
+        name: "${inputs.params.CFGNAME}"
 ```
 
 Except as otherwise noted, the content of this page is licensed under the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -328,10 +328,10 @@ resource definition.
 
 # Pipeline
 
-A [`Pipeline`](pipelines.md) defines a list of tasks to execute, while
-also indicating if any outputs should be used as inputs of a following task by
-using [the `from` field](pipelines.md#from). The same templating you used in
-tasks is also available in pipeline.
+A [`Pipeline`](pipelines.md) defines a list of tasks to execute, while also
+indicating if any outputs should be used as inputs of a following task by using
+[the `from` field](pipelines.md#from). The same templating you used in tasks is
+also available in pipeline.
 
 For example:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,8 +5,12 @@ This directory contains examples of [the Pipeline CRDs](../README.md) in action.
 To deploy them to your cluster (after
 [installing the CRDs and running the controller](../DEVELOPMENT.md#getting-started)):
 
-In few examples to demonstrate tasks that push image to registry, sample URL `gcr.io/christiewilson-catfactory` is used. To run these examples yourself, you will need to change the values of this sample registry URL to a registry you can push to from inside
-your cluster. If you are following instructions [here](../DEVELOPMENT.md#getting-started) to setup then use the value of `${KO_DOCKER_REPO}` instead of `gcr.io/christiewilson-catfactory`.
+In few examples to demonstrate tasks that push image to registry, sample URL
+`gcr.io/christiewilson-catfactory` is used. To run these examples yourself, you
+will need to change the values of this sample registry URL to a registry you can
+push to from inside your cluster. If you are following instructions
+[here](../DEVELOPMENT.md#getting-started) to setup then use the value of
+`${KO_DOCKER_REPO}` instead of `gcr.io/christiewilson-catfactory`.
 
 ```bash
 # To invoke the build-push Task only
@@ -24,8 +28,8 @@ kubectl apply -f examples/taskruns/resource-spec-taskrun.yaml
 
 ## Results
 
-You can track the progress of your taskruns and pipelineruns with this command, which will also
-format the output nicely.
+You can track the progress of your taskruns and pipelineruns with this command,
+which will also format the output nicely.
 
 ```shell
 $ kubectl get taskruns -o=custom-columns-file=./test/columns.txt

--- a/hack/release.md
+++ b/hack/release.md
@@ -100,9 +100,10 @@ a git annotated tag).
 
 #### Release notes
 
-Release notes will need to be manually collected for the release by looking at the
-`Release Notes` section of every PR which has been merged between the last release
-and the current one.
+Release notes will need to be manually collected for the release by looking at
+the `Release Notes` section of every PR which has been merged between the last
+release and the current one.
 
-Visiting [github.com/knative/build-pipeline/compare](https://github.com/knative/build-pipeline/compare)
+Visiting
+[github.com/knative/build-pipeline/compare](https://github.com/knative/build-pipeline/compare)
 will allow you to compare changes between git tags.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`