### PR TITLE
Rename external tutorial repo to reflect project name

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -601,8 +601,8 @@ Tekton Pipelines is known to work with:
 - Logs can remain in-memory only as opposed to sent to a service such as
   [Stackdriver](https://cloud.google.com/logging/).
 
-Elasticsearch can be deployed locally as a means to view logs "after the fact":
-an example is provided at https://github.com/mgreau/knative-elastic-tutorials.
+Elasticsearch, Beats and Kibana can be deployed locally as a means to view logs:
+an example is provided at https://github.com/mgreau/tekton-pipelines-elastic-tutorials.
 
 ## Experimentation
 


### PR DESCRIPTION
This commit renames the external tutorial repository to replace
`knative` with `tekton-pipelines`.

It also updates the list of Elastic components needed to stream the
logs in realtime, used in these tutorials.
