### PR TITLE
Add support for volume templating for PVC, secrets

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -341,9 +341,9 @@ To access an input parameter, replace `resources` with `params`.
 ${inputs.params.<name>}
 ```
 
-**Note**: Task volume names and volume source(current support includes only
-configmap) can also be parameterized as shown in
-[example](#using-kubernetes-configmap-as-volume-source)
+#### Templating Volumes
+
+Task volume names and different [types of volumes](https://kubernetes.io/docs/concepts/storage/volumes/#types-of-volumes) can be parameterized. Current support includes for widely used types of volumes like configmap, secret and PersistentVolumeClaim. Here is an [example](#using-kubernetes-configmap-as-volume-source) on how to use this in Task definitions.
 
 ## Examples
 

--- a/examples/taskruns/taskrun-volume-secret-args.yaml
+++ b/examples/taskruns/taskrun-volume-secret-args.yaml
@@ -1,0 +1,39 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: secret-for-test
+data:
+  ninja: aGVsaW9wb2xpcw==
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-volume-secret-args
+spec:
+  inputs:
+    params:
+    - name: SCNAME
+      description: Name of secret
+  steps:
+  - name: read
+    image: ubuntu
+    args: ["cat", "/secretpath/ninja"]
+    volumeMounts:
+    - name: custom
+      mountPath: /secretpath
+  volumes:
+  - name: custom
+    secret:
+      secretName: "${inputs.params.SCNAME}"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: test-secret-volume-args
+spec:
+  taskRef:
+    name: task-volume-secret-args
+  inputs:
+    params:
+    - name: SCNAME
+      value: secret-for-test

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -96,6 +96,12 @@ func ApplyReplacements(build *buildv1alpha1.Build, replacements map[string]strin
 		if v.VolumeSource.ConfigMap != nil {
 			build.Spec.Volumes[i].ConfigMap.Name = templating.ApplyReplacements(v.ConfigMap.Name, replacements)
 		}
+		if v.VolumeSource.Secret != nil {
+			build.Spec.Volumes[i].Secret.SecretName = templating.ApplyReplacements(v.Secret.SecretName, replacements)
+		}
+		if v.PersistentVolumeClaim != nil {
+			build.Spec.Volumes[i].PersistentVolumeClaim.ClaimName = templating.ApplyReplacements(v.PersistentVolumeClaim.ClaimName, replacements)
+		}
 	}
 
 	return build


### PR DESCRIPTION
## Changes

Users can configure volumes of type PVC and secrets. 
- Added e2e yaml test for secrets.

Both volume types are supported in Build. Porting these features for Task to reach feature parity.

**Note**: I did not add yaml test for PVC because with recent k8s change pods do not wait for PVC to be available. This can lead to false negatives when test fails. This feature is tested at unit test level.

## Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md) for more details._

## Release Notes

```release-note
Add support for templating secret and PVC volume types. 
```