### PR TITLE
Work around markdown lint bug 😭

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -11,7 +11,7 @@ This tutorial will walk you through creating and running some simple
 
 For more details on using `Pipelines`, see [our usage docs](README.md).
 
-**[This tutorial can be run on a local workstation](#local-development)**<br>
+**Note:** [This tutorial can be run on a local workstation](#local-development)
 
 ## Task
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -326,7 +326,7 @@ The status of type `Succeeded = True` shows the Task ran successfully and you
 can also validate the Docker image is created in the location specified in the
 resource definition.
 
-# Pipeline
+## Pipeline
 
 A [`Pipeline`](pipelines.md) defines a list of tasks to execute, while also
 indicating if any outputs should be used as inputs of a following task by using
@@ -603,7 +603,7 @@ Tekton Pipelines is known to work with:
 
 Elasticsearch, Beats and Kibana can be deployed locally as a means to view logs:
 an example is provided at
-https://github.com/mgreau/tekton-pipelines-elastic-tutorials.
+<https://github.com/mgreau/tekton-pipelines-elastic-tutorials>.
 
 ## Experimentation
 


### PR DESCRIPTION
There is a bug in the markdown linter (mdl) that causes it to error out
if a link is bolded, e.g.:

```
**[I am a link](https://example.com)**
```

https://github.com/markdownlint/markdownlint/issues/211

Having the `<br/>` after the link seems to stop this from happening
(maybe that's why @a-roberts added it in the first place?). It wasn't
obvious why the `<br/>` was there so i n #473 I tried to remove it and
then had to spend some time debugging the cryptic ruby error.

## Submitter Checklist

- [x] ~Includes [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)~
- [x] ~Includes [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)~
- [x] Commit messages follow [commit message best practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md) for more details._