### PR TITLE
Remove `logsURL` from step status

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -96,15 +96,13 @@ status:
   podName: echo-hello-world-task-run-pod-85ca51
   startTime: 2018-12-11T15:49:39Z
   steps:
-    - logsURL: ""
-      terminated:
+    - terminated:
         containerID: docker://fcfe4a004...6729d6d2ad53faff41
         exitCode: 0
         finishedAt: 2018-12-11T15:50:01Z
         reason: Completed
         startedAt: 2018-12-11T15:50:01Z
-    - logsURL: ""
-      terminated:
+    - terminated:
         containerID: docker://fe86fc5f7...eb429697b44ce4a5b
         exitCode: 0
         finishedAt: 2018-12-11T15:50:02Z
@@ -306,15 +304,13 @@ status:
   podName: build-docker-image-from-git-source-task-run-pod-24d414
   startTime: 2018-12-11T18:14:29Z
   steps:
-    - logsURL: ""
-      terminated:
+    - terminated:
         containerID: docker://138ce30c722eed....c830c9d9005a0542
         exitCode: 0
         finishedAt: 2018-12-11T18:14:47Z
         reason: Completed
         startedAt: 2018-12-11T18:14:47Z
-    - logsURL: ""
-      terminated:
+    - terminated:
         containerID: docker://4a75136c029fb1....4c94b348d4f67744
         exitCode: 0
         finishedAt: 2018-12-11T18:14:48Z
@@ -512,15 +508,13 @@ status:
       podName: tutorial-pipeline-run-1-build-skaffold-web-pod-21ddf0
       startTime: 2018-12-11T20:30:19Z
       steps:
-        - logsURL: ""
-          terminated:
+        - terminated:
             containerID: docker://c699fcba94....f96108ac9f4db22b94e0c
             exitCode: 0
             finishedAt: 2018-12-11T20:30:36Z
             reason: Completed
             startedAt: 2018-12-11T20:30:36Z
-        - logsURL: ""
-          terminated:
+        - terminated:
             containerID: docker://f5f752d....824262ad6ce7675
             exitCode: 0
             finishedAt: 2018-12-11T20:31:17Z
@@ -534,22 +528,19 @@ status:
       podName: tutorial-pipeline-run-1-deploy-web-pod-7a796b
       startTime: 2018-12-11T20:32:11Z
       steps:
-        - logsURL: ""
-          terminated:
+        - terminated:
             containerID: docker://eaefb7b6d685....f001f895430f71374
             exitCode: 0
             finishedAt: 2018-12-11T20:32:28Z
             reason: Completed
             startedAt: 2018-12-11T20:32:28Z
-        - logsURL: ""
-          terminated:
+        - terminated:
             containerID: docker://4cfc6eba47a7a....dcaef1e9b1eee3661b8a85f
             exitCode: 0
             finishedAt: 2018-12-11T20:32:31Z
             reason: Completed
             startedAt: 2018-12-11T20:32:31Z
-        - logsURL: ""
-          terminated:
+        - terminated:
             containerID: docker://01b376b92....dce4ccec9641d77
             exitCode: 0
             finishedAt: 2018-12-11T20:32:35Z

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -162,12 +162,9 @@ func (tr *TaskRunStatus) SetCondition(newCond *duckv1alpha1.Condition) {
 	}
 }
 
-// StepState reports the results of running a step in the Task. Each
-// task has the potential to succeed or fail (based on the exit code)
-// and produces logs.
+// StepState reports the results of running a step in the Task.
 type StepState struct {
 	corev1.ContainerState
-	LogsURL string `json:"logsURL"`
 }
 
 // +genclient


### PR DESCRIPTION
In #549 @hrishin pointed out that it's hard to understand from the step
status exactly which step did what. While looking at this I realized
that we have included a field `logsURL` which we never populate - I
thought this was copied over from Build but it was actually from our
original prototype API and we have never used it. In #107 we should be
revisiting making logs available and we may add in something like this,
but since we're not using it and it's not clear if we ever will, let's
remove it for now.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes
      [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles)
      (if functionality changed/added) (n/a)
- [x] Includes
      [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles)
      (if user facing) (n/a)
- [x] Commit messages follow [commit message best
      practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
release-note

* Removes the `logsURL` field from `TaskRun` status. This field was never populated and was leftover from the original POC version of the API. #107 may add something like this in the future but that design remains TBD.
```
