### PR TITLE
Preserve GCS directory structures

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -320,7 +320,7 @@ Params that can be added are the following:
    storage artifact is considered not a directory.
    - If artifact is a directory then `-r`(recursive) flag is used to copy all
      files under source directory to GCS bucket. Eg:
-     `gsutil cp -r source_dir gs://some-bucket`
+     `gsutil cp -r source_dir/* gs://some-bucket`
    - If artifact is a single file like zip, tar files then copy will be only 1
      level deep(no recursive). It will not trigger copy of sub directories in
      source directory. Eg: `gsutil cp source.tar gs://some-bucket.tar`.

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -77,7 +77,7 @@ func (b *ArtifactBucket) StorageBasePath(pr *PipelineRun) string {
 
 // GetCopyFromContainerSpec returns a container used to download artifacts from temporary storage
 func (b *ArtifactBucket) GetCopyFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
-	args := []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/%s/**", b.Location, sourcePath), destinationPath)}
+	args := []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/%s/*", b.Location, sourcePath), destinationPath)}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts("bucket", secretVolumeMountPath, b.Secrets)
 

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -41,7 +41,7 @@ func TestBucketGetCopyFromContainerSpec(t *testing.T) {
 	}, {
 		Name:         "artifact-copy-from-workspace-mz4c7",
 		Image:        "override-with-gsutil-image:latest",
-		Args:         []string{"-args", "cp -r gs://fake-bucket/src-path/** /workspace/destination"},
+		Args:         []string{"-args", "cp -r gs://fake-bucket/src-path/* /workspace/destination"},
 		Env:          []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/bucketsecret/secret1/serviceaccount"}},
 		VolumeMounts: []corev1.VolumeMount{{Name: "volume-bucket-secret1", MountPath: "/var/bucketsecret/secret1"}},
 	}}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -134,7 +134,7 @@ func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 	}
 	var args []string
 	if s.TypeDir {
-		args = []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/**", s.Location), s.DestinationDir)}
+		args = []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/*", s.Location), s.DestinationDir)}
 	} else {
 		args = []string{"-args", fmt.Sprintf("cp %s %s", s.Location, s.DestinationDir)}
 	}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -236,7 +236,7 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 		}, {
 			Name:  "fetch-gcs-valid-mz4c7",
 			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp -r gs://some-bucket/** /workspace"},
+			Args:  []string{"-args", "cp -r gs://some-bucket/* /workspace"},
 			Env: []corev1.EnvVar{{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -926,7 +926,7 @@ func Test_StorageInputResource(t *testing.T) {
 				}, {
 					Name:  "fetch-storage-gcs-keys-mz4c7",
 					Image: "override-with-gsutil-image:latest",
-					Args:  []string{"-args", "cp -r gs://fake-bucket/rules.zip/** /workspace/gcs-input-resource"},
+					Args:  []string{"-args", "cp -r gs://fake-bucket/rules.zip/* /workspace/gcs-input-resource"},
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"},
 					},
@@ -1029,7 +1029,7 @@ func TestAddStepsToBuild_WithBucketFromConfigMap(t *testing.T) {
 			}, {
 				Name:  "artifact-copy-from-gitspace-0-78c5n",
 				Image: "override-with-gsutil-image:latest",
-				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/** /workspace/gitspace"},
+				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gitspace"},
 			}},
 		},
 	}, {
@@ -1065,7 +1065,7 @@ func TestAddStepsToBuild_WithBucketFromConfigMap(t *testing.T) {
 			}, {
 				Name:  "artifact-copy-from-workspace-0-j2tds",
 				Image: "override-with-gsutil-image:latest",
-				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/** /workspace/gcs-dir"},
+				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gcs-dir"},
 			}},
 		},
 	}} {


### PR DESCRIPTION
# Changes

This change allows GCS pipeline resources using directories to preserve
directory structures instead of flattening the files.

Fixes #522

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)

# Release Notes

```
PipelineResources storage GCS for directories now preserves directory structures during copies.
```
