### PR TITLE
Update go-containerregistry to latest master.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -199,7 +199,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:5e8baba12287b07e83ba7447739ffb80d6275f399d5dd7b33f3f72ecce4cec1c"
+  digest = "1:2d701965b8d2b2351afab35af19efc3f07b28f64449d1969d7b29bb120a77cf3"
   name = "github.com/google/go-containerregistry"
   packages = [
     "pkg/authn",
@@ -215,7 +215,7 @@
     "pkg/v1/v1util",
   ]
   pruneopts = "NUT"
-  revision = "dbc4da98389f9d0c42eb314c2b346bf1d2a27310"
+  revision = "fcd5acbb4e785f428f197ddd66a8931df6923fe6"
 
 [[projects]]
   digest = "1:f9425215dccf1c63f659ec781ca46bc81804341821d0cd8d2459c5b58f8bd067"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,8 +45,8 @@ required = [
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"
-  # HEAD as of 2019-02-06
-  revision = "dbc4da98389f9d0c42eb314c2b346bf1d2a27310"
+  # HEAD as of 2019-03-07
+  revision = "fcd5acbb4e785f428f197ddd66a8931df6923fe6"
 
 [[override]]
   name = "github.com/golang/protobuf"

--- a/vendor/github.com/google/go-containerregistry/pkg/name/digest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/name/digest.go
@@ -73,14 +73,14 @@ func NewDigest(name string, strict Strictness) (Digest, error) {
 	base := parts[0]
 	digest := parts[1]
 
-	// We don't require a digest, but if we get one check it's valid,
-	// even when not being strict.
-	// If we are being strict, we want to validate the digest regardless in case
-	// it's empty.
-	if digest != "" || strict == StrictValidation {
-		if err := checkDigest(digest); err != nil {
-			return Digest{}, err
-		}
+	// Always check that the digest is valid.
+	if err := checkDigest(digest); err != nil {
+		return Digest{}, err
+	}
+
+	tag, err := NewTag(base, strict)
+	if err == nil {
+		base = tag.Repository.Name()
 	}
 
 	repo, err := NewRepository(base, strict)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/config.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/config.go
@@ -21,27 +21,28 @@ import (
 )
 
 // ConfigFile is the configuration file that holds the metadata describing
-// how to launch a container.  The names of the fields are chosen to reflect
-// the JSON payload of the ConfigFile as defined here: https://git.io/vrAEY
+// how to launch a container. See:
+// https://github.com/opencontainers/image-spec/blob/master/config.md
 type ConfigFile struct {
 	Architecture    string    `json:"architecture"`
-	Container       string    `json:"container"`
-	Created         Time      `json:"created"`
-	DockerVersion   string    `json:"docker_version"`
-	History         []History `json:"history"`
+	Author          string    `json:"author,omitempty"`
+	Container       string    `json:"container,omitempty"`
+	Created         Time      `json:"created,omitempty"`
+	DockerVersion   string    `json:"docker_version,omitempty"`
+	History         []History `json:"history,omitempty"`
 	OS              string    `json:"os"`
 	RootFS          RootFS    `json:"rootfs"`
 	Config          Config    `json:"config"`
-	ContainerConfig Config    `json:"container_config"`
-	OSVersion       string    `json:"osversion"`
+	ContainerConfig Config    `json:"container_config,omitempty"`
+	OSVersion       string    `json:"osversion,omitempty"`
 }
 
 // History is one entry of a list recording how this container image was built.
 type History struct {
-	Author     string `json:"author"`
-	Created    Time   `json:"created"`
-	CreatedBy  string `json:"created_by"`
-	Comment    string `json:"comment"`
+	Author     string `json:"author,omitempty"`
+	Created    Time   `json:"created,omitempty"`
+	CreatedBy  string `json:"created_by,omitempty"`
+	Comment    string `json:"comment,omitempty"`
 	EmptyLayer bool   `json:"empty_layer,omitempty"`
 }
 

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/image.go
@@ -24,9 +24,6 @@ type Image interface {
 	// The order of the list is oldest/base layer first, and most-recent/top layer last.
 	Layers() ([]Layer, error)
 
-	// BlobSet returns an unordered collection of all the blobs in the image.
-	BlobSet() (map[Hash]struct{}, error)
-
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/index.go
@@ -29,6 +29,12 @@ type ImageIndex interface {
 	// IndexManifest returns this image index's manifest object.
 	IndexManifest() (*IndexManifest, error)
 
-	// RawIndexManifest returns the serialized bytes of IndexManifest().
-	RawIndexManifest() ([]byte, error)
+	// RawManifest returns the serialized bytes of IndexManifest().
+	RawManifest() ([]byte, error)
+
+	// Image returns a v1.Image that this ImageIndex references.
+	Image(Hash) (Image, error)
+
+	// ImageIndex returns a v1.ImageIndex that this ImageIndex references.
+	ImageIndex(Hash) (ImageIndex, error)
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/compressed.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/compressed.go
@@ -91,11 +91,6 @@ type compressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*compressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *compressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *compressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/uncompressed.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/uncompressed.go
@@ -112,11 +112,6 @@ type uncompressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*uncompressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *uncompressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *uncompressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/with.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/with.go
@@ -191,20 +191,6 @@ func FSLayers(i WithManifest) ([]v1.Hash, error) {
 	return fsl, nil
 }
 
-// BlobSet is a helper for implementing v1.Image
-func BlobSet(i WithManifest) (map[v1.Hash]struct{}, error) {
-	m, err := i.Manifest()
-	if err != nil {
-		return nil, err
-	}
-	bs := make(map[v1.Hash]struct{})
-	for _, l := range m.Layers {
-		bs[l.Digest] = struct{}{}
-	}
-	bs[m.Config.Digest] = struct{}{}
-	return bs, nil
-}
-
 // BlobSize is a helper for implementing v1.Image
 func BlobSize(i WithManifest, h v1.Hash) (int64, error) {
 	m, err := i.Manifest()

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/image.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -34,12 +35,12 @@ import (
 
 // remoteImage accesses an image from a remote registry
 type remoteImage struct {
-	ref          name.Reference
-	client       *http.Client
+	fetcher
 	manifestLock sync.Mutex // Protects manifest
 	manifest     []byte
 	configLock   sync.Mutex // Protects config
 	config       []byte
+	mediaType    types.MediaType
 }
 
 // ImageOption is a functional option for Image.
@@ -60,8 +61,10 @@ func (i *imageOpener) Open() (v1.Image, error) {
 		return nil, err
 	}
 	ri := &remoteImage{
-		ref:    i.ref,
-		client: &http.Client{Transport: tr},
+		fetcher: fetcher{
+			Ref:    i.ref,
+			Client: &http.Client{Transport: tr},
+		},
 	}
 	imgCore, err := partial.CompressedToImage(ri)
 	if err != nil {
@@ -92,58 +95,57 @@ func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
 	return img.Open()
 }
 
-func (r *remoteImage) url(resource, identifier string) url.URL {
+// fetcher implements methods for reading from a remote image.
+type fetcher struct {
+	Ref    name.Reference
+	Client *http.Client
+}
+
+// url returns a url.Url for the specified path in the context of this remote image reference.
+func (f *fetcher) url(resource, identifier string) url.URL {
 	return url.URL{
-		Scheme: r.ref.Context().Registry.Scheme(),
-		Host:   r.ref.Context().RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/%s/%s", r.ref.Context().RepositoryStr(), resource, identifier),
+		Scheme: f.Ref.Context().Registry.Scheme(),
+		Host:   f.Ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
 	}
 }
 
-func (r *remoteImage) MediaType() (types.MediaType, error) {
-	// TODO(jonjohnsonjr): Determine this based on response.
-	return types.DockerManifestSchema2, nil
-}
-
-// TODO(jonjohnsonjr): Handle manifest lists.
-func (r *remoteImage) RawManifest() ([]byte, error) {
-	r.manifestLock.Lock()
-	defer r.manifestLock.Unlock()
-	if r.manifest != nil {
-		return r.manifest, nil
-	}
-
-	u := r.url("manifests", r.ref.Identifier())
+func (f *fetcher) fetchManifest(acceptable []types.MediaType) ([]byte, *v1.Descriptor, error) {
+	u := f.url("manifests", f.Ref.Identifier())
 	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	// TODO(jonjohnsonjr): Accept OCI manifest, manifest list, and image index.
-	req.Header.Set("Accept", string(types.DockerManifestSchema2))
-	resp, err := r.client.Do(req)
+	accept := []string{}
+	for _, mt := range acceptable {
+		accept = append(accept, string(mt))
+	}
+	req.Header.Set("Accept", strings.Join(accept, ","))
+
+	resp, err := f.Client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 
 	if err := transport.CheckError(resp, http.StatusOK); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	manifest, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	digest, _, err := v1.SHA256(bytes.NewReader(manifest))
+	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Validate the digest matches what we asked for, if pulling by digest.
-	if dgst, ok := r.ref.(name.Digest); ok {
+	if dgst, ok := f.Ref.(name.Digest); ok {
 		if digest.String() != dgst.DigestStr() {
-			return nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), r.ref)
+			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
 		}
 	} else {
 		// Do nothing for tags; I give up.
@@ -156,6 +158,42 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		// https://github.com/GoogleContainerTools/kaniko/issues/298
 	}
 
+	// Return all this info since we have to calculate it anyway.
+	desc := v1.Descriptor{
+		Digest:    digest,
+		Size:      size,
+		MediaType: types.MediaType(resp.Header.Get("Content-Type")),
+	}
+
+	return manifest, &desc, nil
+}
+
+func (r *remoteImage) MediaType() (types.MediaType, error) {
+	if string(r.mediaType) != "" {
+		return r.mediaType, nil
+	}
+	return types.DockerManifestSchema2, nil
+}
+
+// TODO(jonjohnsonjr): Handle manifest lists.
+func (r *remoteImage) RawManifest() ([]byte, error) {
+	r.manifestLock.Lock()
+	defer r.manifestLock.Unlock()
+	if r.manifest != nil {
+		return r.manifest, nil
+	}
+
+	// TODO(jonjohnsonjr): Accept manifest list and image index?
+	acceptable := []types.MediaType{
+		types.DockerManifestSchema2,
+		types.OCIManifestSchema1,
+	}
+	manifest, desc, err := r.fetchManifest(acceptable)
+	if err != nil {
+		return nil, err
+	}
+
+	r.mediaType = desc.MediaType
 	r.manifest = manifest
 	return r.manifest, nil
 }
@@ -203,7 +241,7 @@ func (rl *remoteLayer) Digest() (v1.Hash, error) {
 // Compressed implements partial.CompressedLayer
 func (rl *remoteLayer) Compressed() (io.ReadCloser, error) {
 	u := rl.ri.url("blobs", rl.digest.String())
-	resp, err := rl.ri.client.Get(u.String())
+	resp, err := rl.ri.Client.Get(u.String())
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/index.go
@@ -1,0 +1,139 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// remoteIndex accesses an index from a remote registry
+type remoteIndex struct {
+	fetcher
+	manifestLock sync.Mutex // Protects manifest
+	manifest     []byte
+	mediaType    types.MediaType
+}
+
+// Index provides access to a remote index reference, applying functional options
+// to the underlying imageOpener before resolving the reference into a v1.ImageIndex.
+func Index(ref name.Reference, options ...ImageOption) (v1.ImageIndex, error) {
+	i := &imageOpener{
+		auth:      authn.Anonymous,
+		transport: http.DefaultTransport,
+		ref:       ref,
+	}
+
+	for _, option := range options {
+		if err := option(i); err != nil {
+			return nil, err
+		}
+	}
+	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, err
+	}
+	return &remoteIndex{
+		fetcher: fetcher{
+			Ref:    i.ref,
+			Client: &http.Client{Transport: tr},
+		},
+	}, nil
+}
+
+func (r *remoteIndex) MediaType() (types.MediaType, error) {
+	if string(r.mediaType) != "" {
+		return r.mediaType, nil
+	}
+	return types.DockerManifestList, nil
+}
+
+func (r *remoteIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(r)
+}
+
+func (r *remoteIndex) RawManifest() ([]byte, error) {
+	r.manifestLock.Lock()
+	defer r.manifestLock.Unlock()
+	if r.manifest != nil {
+		return r.manifest, nil
+	}
+
+	acceptable := []types.MediaType{
+		types.DockerManifestList,
+		types.OCIImageIndex,
+	}
+	manifest, desc, err := r.fetchManifest(acceptable)
+	if err != nil {
+		return nil, err
+	}
+
+	r.mediaType = desc.MediaType
+	r.manifest = manifest
+	return r.manifest, nil
+}
+
+func (r *remoteIndex) IndexManifest() (*v1.IndexManifest, error) {
+	b, err := r.RawManifest()
+	if err != nil {
+		return nil, err
+	}
+	return v1.ParseIndexManifest(bytes.NewReader(b))
+}
+
+func (r *remoteIndex) Image(h v1.Hash) (v1.Image, error) {
+	imgRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	if err != nil {
+		return nil, err
+	}
+	ri := &remoteImage{
+		fetcher: fetcher{
+			Ref:    imgRef,
+			Client: r.Client,
+		},
+	}
+	imgCore, err := partial.CompressedToImage(ri)
+	if err != nil {
+		return imgCore, err
+	}
+	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
+	// remote.Write calls to facilitate cross-repo "mounting".
+	return &mountableImage{
+		Image:     imgCore,
+		Reference: r.Ref,
+	}, nil
+}
+
+func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	idxRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	if err != nil {
+		return nil, err
+	}
+	return &remoteIndex{
+		fetcher: fetcher{
+			Ref:    idxRef,
+			Client: r.Client,
+		},
+	}, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/write.go
@@ -29,8 +29,15 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"golang.org/x/sync/errgroup"
 )
+
+type manifest interface {
+	RawManifest() ([]byte, error)
+	MediaType() (types.MediaType, error)
+	Digest() (v1.Hash, error)
+}
 
 // Write pushes the provided img to the specified image reference.
 func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.RoundTripper) error {
@@ -47,13 +54,28 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 	w := writer{
 		ref:    ref,
 		client: &http.Client{Transport: tr},
-		img:    img,
 	}
 
 	// Upload individual layers in goroutines and collect any errors.
+	// If we can dedupe by the layer digest, try to do so. If the layer is
+	// a stream.Layer, we can't dedupe and might re-upload.
 	var g errgroup.Group
+	uploaded := map[v1.Hash]bool{}
 	for _, l := range ls {
 		l := l
+		if _, ok := l.(*stream.Layer); !ok {
+			h, err := l.Digest()
+			if err != nil {
+				return err
+			}
+			// If we can determine the layer's digest ahead of
+			// time, use it to dedupe uploads.
+			if uploaded[h] {
+				continue // Already uploading.
+			}
+			uploaded[h] = true
+		}
+
 		g.Go(func() error {
 			return w.uploadOne(l)
 		})
@@ -91,14 +113,13 @@ func Write(ref name.Reference, img v1.Image, auth authn.Authenticator, t http.Ro
 
 	// With all of the constituent elements uploaded, upload the manifest
 	// to commit the image.
-	return w.commitImage()
+	return w.commitImage(img)
 }
 
 // writer writes the elements of an image to a remote image reference.
 type writer struct {
 	ref    name.Reference
 	client *http.Client
-	img    v1.Image
 }
 
 // url returns a url.Url for the specified path in the context of this remote image reference.
@@ -126,14 +147,38 @@ func (w *writer) nextLocation(resp *http.Response) (string, error) {
 	return resp.Request.URL.ResolveReference(u).String(), nil
 }
 
-// checkExisting checks if a blob exists already in the repository by making a
+// checkExistingBlob checks if a blob exists already in the repository by making a
 // HEAD request to the blob store API.  GCR performs an existence check on the
 // initiation if "mount" is specified, even if no "from" sources are specified.
 // However, this is not broadly applicable to all registries, e.g. ECR.
-func (w *writer) checkExisting(h v1.Hash) (bool, error) {
+func (w *writer) checkExistingBlob(h v1.Hash) (bool, error) {
 	u := w.url(fmt.Sprintf("/v2/%s/blobs/%s", w.ref.Context().RepositoryStr(), h.String()))
 
 	resp, err := w.client.Head(u.String())
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK, http.StatusNotFound); err != nil {
+		return false, err
+	}
+
+	return resp.StatusCode == http.StatusOK, nil
+}
+
+// checkExistingManifest checks if a manifest exists already in the repository
+// by making a HEAD request to the manifest API.
+func (w *writer) checkExistingManifest(h v1.Hash, mt types.MediaType) (bool, error) {
+	u := w.url(fmt.Sprintf("/v2/%s/manifests/%s", w.ref.Context().RepositoryStr(), h.String()))
+
+	req, err := http.NewRequest(http.MethodHead, u.String(), nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Accept", string(mt))
+
+	resp, err := w.client.Do(req)
 	if err != nil {
 		return false, err
 	}
@@ -254,7 +299,7 @@ func (w *writer) uploadOne(l v1.Layer) error {
 		}
 		digest = h.String()
 
-		existing, err := w.checkExisting(h)
+		existing, err := w.checkExistingBlob(h)
 		if err != nil {
 			return err
 		}
@@ -306,12 +351,12 @@ func (w *writer) uploadOne(l v1.Layer) error {
 }
 
 // commitImage does a PUT of the image's manifest.
-func (w *writer) commitImage() error {
-	raw, err := w.img.RawManifest()
+func (w *writer) commitImage(man manifest) error {
+	raw, err := man.RawManifest()
 	if err != nil {
 		return err
 	}
-	mt, err := w.img.MediaType()
+	mt, err := man.MediaType()
 	if err != nil {
 		return err
 	}
@@ -335,7 +380,7 @@ func (w *writer) commitImage() error {
 		return err
 	}
 
-	digest, err := w.img.Digest()
+	digest, err := man.Digest()
 	if err != nil {
 		return err
 	}
@@ -369,4 +414,61 @@ func scopesForUploadingImage(ref name.Reference, layers []v1.Layer) []string {
 	return scopes
 }
 
-// TODO(mattmoor): WriteIndex
+// WriteIndex pushes the provided ImageIndex to the specified image reference.
+// WriteIndex will attempt to push all of the referenced manifests before
+// attempting to push the ImageIndex, to retain referential integrity.
+func WriteIndex(ref name.Reference, ii v1.ImageIndex, auth authn.Authenticator, t http.RoundTripper) error {
+	index, err := ii.IndexManifest()
+	if err != nil {
+		return err
+	}
+
+	scopes := []string{ref.Scope(transport.PushScope)}
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
+	if err != nil {
+		return err
+	}
+	w := writer{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	}
+
+	for _, desc := range index.Manifests {
+		ref, err := name.ParseReference(fmt.Sprintf("%s@%s", ref.Context(), desc.Digest), name.StrictValidation)
+		if err != nil {
+			return err
+		}
+		exists, err := w.checkExistingManifest(desc.Digest, desc.MediaType)
+		if err != nil {
+			return err
+		}
+		if exists {
+			log.Printf("existing manifest: %v", desc.Digest)
+			continue
+		}
+
+		switch desc.MediaType {
+		case types.OCIImageIndex, types.DockerManifestList:
+			ii, err := ii.ImageIndex(desc.Digest)
+			if err != nil {
+				return err
+			}
+
+			if err := WriteIndex(ref, ii, auth, t); err != nil {
+				return err
+			}
+		case types.OCIManifestSchema1, types.DockerManifestSchema2:
+			img, err := ii.Image(desc.Digest)
+			if err != nil {
+				return err
+			}
+			if err := Write(ref, img, auth, t); err != nil {
+				return err
+			}
+		}
+	}
+
+	// With all of the constituent elements uploaded, upload the manifest
+	// to commit the image.
+	return w.commitImage(ii)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/v1util/zip.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/v1util/zip.go
@@ -73,7 +73,11 @@ func GunzipReadCloser(r io.ReadCloser) (io.ReadCloser, error) {
 // IsGzipped detects whether the input stream is compressed.
 func IsGzipped(r io.Reader) (bool, error) {
 	magicHeader := make([]byte, 2)
-	if _, err := r.Read(magicHeader); err != nil {
+	n, err := r.Read(magicHeader)
+	if n == 0 && err == io.EOF {
+		return false, nil
+	}
+	if err != nil {
 		return false, err
 	}
 	return bytes.Equal(magicHeader, gzipMagicHeader), nil


### PR DESCRIPTION
This is to pick up a fix for resolving names with tags and digests.
This was always a problem in build-pipeline, but was exacerbated by our
move away from init containers.
